### PR TITLE
fix: document nodes need a single root element

### DIFF
--- a/src/components/document/ArticleNode.vue
+++ b/src/components/document/ArticleNode.vue
@@ -1,7 +1,9 @@
 <template>
-  Article
-  <br>
-  {{ data }}
+  <div>
+    Article
+    <br>
+    {{ data }}
+  </div>
 </template>
 
 <script setup lang="ts">

--- a/src/components/document/HttpOperation.vue
+++ b/src/components/document/HttpOperation.vue
@@ -1,7 +1,9 @@
 <template>
-  IHttpOperation
-  <br>
-  {{ data }}
+  <div>
+    IHttpOperation
+    <br>
+    {{ data }}
+  </div>
 </template>
 
 <script setup lang="ts">

--- a/src/components/document/HttpService.vue
+++ b/src/components/document/HttpService.vue
@@ -1,7 +1,9 @@
 <template>
-  HttpService
-  <br>
-  {{ data }}
+  <div>
+    HttpService
+    <br>
+    {{ data }}
+  </div>
 </template>
 
 <script setup lang="ts">

--- a/src/components/document/HttpWebhookOperation.vue
+++ b/src/components/document/HttpWebhookOperation.vue
@@ -1,7 +1,9 @@
 <template>
-  IHttpWebhookOperation
-  <br>
-  {{ data }}
+  <div>
+    IHttpWebhookOperation
+    <br>
+    {{ data }}
+  </div>
 </template>
 
 <script setup lang="ts">

--- a/src/components/document/ModelNode.vue
+++ b/src/components/document/ModelNode.vue
@@ -1,37 +1,39 @@
 <template>
-  <h3>
-    {{ title }} <code v-if="data.type">{{ data.type }}</code>
-  </h3>
-  <p v-if="data.description">
-    {{ data.description }}
-  </p>
-  <p v-if="data.example || data.examples">
-    Example: {{ data.example || data.examples }}
-  </p>
-  <p v-if="data.enum">
-    <span>Allowed values: </span> {{ data.enum }}
-  </p>
+  <div>
+    <h3>
+      {{ title }} <code v-if="data.type">{{ data.type }}</code>
+    </h3>
+    <p v-if="data.description">
+      {{ data.description }}
+    </p>
+    <p v-if="data.example || data.examples">
+      Example: {{ data.example || data.examples }}
+    </p>
+    <p v-if="data.enum">
+      <span>Allowed values: </span> {{ data.enum }}
+    </p>
 
-  <template v-if="modelPropertyProps">
-    <ModelProperty
-      v-for="(property, propertyName) in modelPropertyProps.properties"
-      :key="propertyName"
-      :data-testid="`model-property-${propertyName}`"
-      :property="property"
-      :property-name="propertyName.toString()"
-      :required-fields="modelPropertyProps.required"
+    <template v-if="modelPropertyProps">
+      <ModelProperty
+        v-for="(property, propertyName) in modelPropertyProps.properties"
+        :key="propertyName"
+        :data-testid="`model-property-${propertyName}`"
+        :property="property"
+        :property-name="propertyName.toString()"
+        :required-fields="modelPropertyProps.required"
+      />
+    </template>
+
+    <PropertyOneOf
+      v-if="Array.isArray(data.oneOf) && data.oneOf?.length"
+      :one-of-list="data.oneOf"
     />
-  </template>
 
-  <PropertyOneOf
-    v-if="Array.isArray(data.oneOf) && data.oneOf?.length"
-    :one-of-list="data.oneOf"
-  />
-
-  <PropertyAnyOf
-    v-if="Array.isArray(data.anyOf) && data.anyOf?.length"
-    :any-of-list="data.anyOf"
-  />
+    <PropertyAnyOf
+      v-if="Array.isArray(data.anyOf) && data.anyOf?.length"
+      :any-of-list="data.anyOf"
+    />
+  </div>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
# Summary

Update all of the `/src/components/document` nodes to have a single root element within the `<template>` so that any attributes (e.g. `title` or `data-testid`) can properly resolve without the following warning:

```md
Extraneous non-props attributes were passed to component but could not be automatically inherited because component renders fragment or text root nodes.
```

**Note**: the only change in the PR is wrapping elements with a single `<div>`