### PR TITLE
fix: do not hardcode background color in TOC

### DIFF
--- a/sandbox/App.vue
+++ b/sandbox/App.vue
@@ -19,6 +19,9 @@
 .spec-render-doc {
   --kui-color-background-transparent: lightgreen;
 }
+.table-of-contents {
+   --kui-color-background-transparent: lightgray;
+}
 </style>
 
 <style lang="scss" scoped>

--- a/src/components/spec-renderer-toc/SpecRendererToc.vue
+++ b/src/components/spec-renderer-toc/SpecRendererToc.vue
@@ -51,9 +51,8 @@ const selectItem = (id: any) => {
 
 <style lang="scss" scoped>
 .table-of-contents {
-  background-color: lightgray;
+  background-color: var(--kui-color-background-transparent, $kui-color-background-transparent);
   overflow-y: auto;
-  width: 500px;
   ul {
     list-style: none;
   }


### PR DESCRIPTION
# Summary

This is temporarily fix to make portal look less ugly now as spec-renderer styles about to get loaded into portal: 
![image](https://github.com/Kong/spec-renderer/assets/4562608/dfc77ed9-dd8e-402b-993d-4a7df0fb9a8a)
