### PR TITLE
fix: exclude spec files from tsconfig.build [KHCP-11974]

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,12 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "exclude": [
-    "src/__template__",
-    "src/tests",
-    "src/component-list.ts",
-    "src/temp-generated-component-list.ts",
     "sandbox",
     "node_modules",
     "dist",
+    "src/**/*.spec.ts",
   ],
 }


### PR DESCRIPTION
# Summary

Without this our dist folder gets incorrect structure: 
instead of 
```
dist/types/index.d.ts
```

it becomes: 
```
dist/types/src/index.d.ts
```
and as a result consumer build fails with: `Could not find a declaration file for module '@kong/spec-renderer-dev'` 