### PR TITLE
fix(spec-document): we cannot remove margin for every element in container

### DIFF
--- a/src/components/spec-document/SpecDocument.vue
+++ b/src/components/spec-document/SpecDocument.vue
@@ -64,9 +64,5 @@ watch(() => ({ pathname: props.currentPath, document: props.document }), ({ path
 .spec-renderer-document {
     background-color: var(--kui-color-background-transparent, $kui-color-background-transparent);
     padding: var(--kui-space-60, $kui-space-60);
-
-    * {
-      margin: var(--kui-space-0, $kui-space-0);
-    }
 }
 </style>


### PR DESCRIPTION
# Summary

Need to remove this catch-all rule; it's interfering with basic element styling in Portal with the document.
