### PR TITLE
fix(http-operation): acess URL on server if server present

### DIFF
--- a/src/components/spec-document/HttpOperation.vue
+++ b/src/components/spec-document/HttpOperation.vue
@@ -77,7 +77,7 @@ const setAuthHeaders = (newHeaders: Array<Record<string, string>>) => {
   authHeaders.value = newHeaders
 }
 // this is the server selected by user, defaults to first server in the list
-const selectedServerURL = ref<string>(props.data.servers?.[0].url ?? '')
+const selectedServerURL = ref<string>(props.data.servers?.[0]?.url ?? '')
 
 const serverList = computed(() => props.data.servers?.map(server => server.url) ?? [])
 


### PR DESCRIPTION
# Summary

Was accessing `url` property on `server` without ensuring `server` is present.
Doesn't break for spec without servers, anymore.

<img width="1248" alt="image" src="https://github.com/Kong/spec-renderer/assets/47082523/82d342ed-d7f4-49ab-a272-fe209f7407e1">
