### PR TITLE
feat: add spec version field to parsed spec document [KHCP-12251, KHCP-12357]

### DIFF
--- a/src/components/common/VersionBadge.vue
+++ b/src/components/common/VersionBadge.vue
@@ -1,11 +1,11 @@
 <template>
-  <div
+  <span
     class="version-badge"
     :class="type"
     data-testid="version-badge"
   >
-    <slot>{{ version }}</slot>
-  </div>
+    {{ version }}
+  </span>
 </template>
 
 <script setup lang="ts">

--- a/src/components/spec-document/HttpService.vue
+++ b/src/components/spec-document/HttpService.vue
@@ -4,17 +4,16 @@
       class="overview-page-header"
       :title="data.name"
     >
-      <p class="overview-page-versions">
-        <VersionBadge type="primary">
-          v{{ data.version }}
-        </VersionBadge>
+      <div class="overview-page-versions">
         <VersionBadge
-          v-if="openApiVersion"
+          type="primary"
+          :version="`v${data.version}`"
+        />
+        <VersionBadge
           type="neutral"
-        >
-          OAS {{ openApiVersion }}
-        </VersionBadge>
-      </p>
+          :version="specVersion"
+        />
+      </div>
     </PageHeader>
 
     <section class="overview-page-content">
@@ -56,10 +55,9 @@ defineProps({
     type: Object as PropType<IHttpService>,
     required: true,
   },
-  // todo: pass value for this prop from SpecDocument
-  openApiVersion: {
+  specVersion: {
     type: String,
-    default: '',
+    required: true,
   },
 })
 </script>

--- a/src/components/spec-document/SpecDocument.vue
+++ b/src/components/spec-document/SpecDocument.vue
@@ -74,8 +74,7 @@ const docComponent = computed(() => {
     case NodeType.HttpWebhook:
       return { component: HttpOperation, props: defaultProps }
     case NodeType.HttpService:
-      // todo: add openApiVersion to props
-      return { component: HttpService, props: defaultProps }
+      return { component: HttpService, props: { ...defaultProps, specVersion: serviceNode.value.specVersion } }
     case NodeType.Model:
       return { component: HttpModel, props: { ...defaultProps, title: serviceNode.value.name } }
     default:

--- a/src/stoplight/elements/utils/oas/index.ts
+++ b/src/stoplight/elements/utils/oas/index.ts
@@ -27,7 +27,7 @@ import { oas2SourceMap } from './oas2'
 import { oas3SourceMap } from './oas3'
 
 import type { ISourceNodeMap, ServiceChildNode, ServiceNode } from './types'
-import { NodeTypes } from './types'
+import { NodeTypes, SpecVersion } from './types'
 type OpenAPIObject = _OpenAPIObject & {
   webhooks?: PathObject;
 }
@@ -56,12 +56,13 @@ export function transformOasToServiceNode(apiDescriptionDocument: unknown) {
       oas3SourceMap,
       transformOas3Service,
       transformOas3Operation,
+      SpecVersion.OAS31,
     )
   }
   if (isOas3(apiDescriptionDocument)) {
-    return computeServiceNode(apiDescriptionDocument, oas3SourceMap, transformOas3Service, transformOas3Operation)
+    return computeServiceNode(apiDescriptionDocument, oas3SourceMap, transformOas3Service, transformOas3Operation, SpecVersion.OAS3)
   } else if (isOas2(apiDescriptionDocument)) {
-    return computeServiceNode(apiDescriptionDocument, oas2SourceMap, transformOas2Service, transformOas2Operation)
+    return computeServiceNode(apiDescriptionDocument, oas2SourceMap, transformOas2Service, transformOas2Operation, SpecVersion.OAS2)
   }
 
   return null
@@ -71,6 +72,7 @@ function computeServiceNode(
   map: ISourceNodeMap[],
   transformService: Oas2HttpServiceTransformer | Oas3HttpServiceTransformer,
   transformOperation: Oas2HttpOperationTransformer | Oas3HttpEndpointOperationTransformer,
+  specVersion: SpecVersion,
 ) {
   const serviceDocument = transformService({ document })
   const serviceNode: ServiceNode = {
@@ -80,6 +82,7 @@ function computeServiceNode(
     data: serviceDocument,
     tags: serviceDocument.tags?.map(tag => tag.name) || [],
     children: computeChildNodes(document, document, map, transformOperation),
+    specVersion,
   }
 
   return serviceNode

--- a/src/stoplight/elements/utils/oas/types.ts
+++ b/src/stoplight/elements/utils/oas/types.ts
@@ -27,8 +27,14 @@ type Node<T, D> = {
   tags: string[];
 }
 
+export enum SpecVersion {
+  OAS2 = 'OAS 2.0',
+  OAS3 = 'OAS 3.0',
+  OAS31 = 'OAS 3.1',
+}
+
 export type OperationNode = Node<NodeType.HttpOperation, IHttpOperation>
 export type WebhookNode = Node<NodeType.HttpWebhook, IHttpWebhookOperation>
 export type SchemaNode = Node<NodeType.Model, JSONSchema7>
 export type ServiceChildNode = OperationNode | WebhookNode | SchemaNode
-export type ServiceNode = Node<NodeType.HttpService, IHttpService> & { children: ServiceChildNode[] }
+export type ServiceNode = Node<NodeType.HttpService, IHttpService> & { children: ServiceChildNode[] } & { specVersion: SpecVersion }


### PR DESCRIPTION
# Summary

This PR adds a new `specVersion` field to the parsed spec document.

## Changes

- add `specVersion` field to `ServiceNode` type and a new `SpecVersion` enum
- add a `specVersion` param to `computeServiceNode` function in `stoplight/elements/utils/oas/index.ts`
  - the `computeServiceNode` function is only called after we do a check for the spec version, so we can easily pass the corresponding sec version as a param to it

## Previews

<img width="230" alt="image" src="https://github.com/Kong/spec-renderer/assets/47082523/3214565c-a5b8-4bf9-89c8-65d4c185050c">

<img width="254" alt="image" src="https://github.com/Kong/spec-renderer/assets/47082523/0312f4c3-6cf5-4dd0-949b-32ae54eae53f">


Jira tickets: 
- https://konghq.atlassian.net/browse/KHCP-12251
- https://konghq.atlassian.net/browse/KHCP-12357
