### PR TITLE
fix(shiki): highlighter method rename

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "lodash": "^4.17.21",
     "oas-normalize": "^11.1.0",
     "openapi3-ts": "4.3.3",
-    "shiki": "^1.6.4"
+    "shiki": "^1.9.0"
   },
   "resolutions": {
     "openapi3-ts": "4.3.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: 4.3.3
         version: 4.3.3
       shiki:
-        specifier: ^1.6.4
-        version: 1.6.4
+        specifier: ^1.9.0
+        version: 1.9.0
     devDependencies:
       '@babel/types':
         specifier: ^7.24.7
@@ -679,7 +679,6 @@ packages:
 
   '@evilmartians/lefthook@1.6.18':
     resolution: {integrity: sha512-nvJ1uYgz/F1DbykTMIiI2nUZctVmijUYkqdGqmGkrL0ImEKFjWxk1jZg6pULJ5vWxsArfUFJiFuOhUnUhyMbig==}
-    cpu: [x64, arm64, ia32]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -1013,8 +1012,8 @@ packages:
     resolution: {integrity: sha512-I+6l2vZ4qx+RyUo8GNnIbeqbv5ao1enSdNFPJ7x3slIVLU8aSBf228qpo+6iNWbRMK4ktF91jsv5KN7PpaJQtg==}
     hasBin: true
 
-  '@shikijs/core@1.6.4':
-    resolution: {integrity: sha512-WTU9rzZae1p2v6LOxMf6LhtmZOkIHYYW160IuahUyJy7YXPPjyWZLR1ag+SgD22ZMxZtz1gfU6Tccc8t0Il/XA==}
+  '@shikijs/core@1.9.0':
+    resolution: {integrity: sha512-cbSoY8P/jgGByG8UOl3jnP/CWg/Qk+1q+eAKWtcrU3pNoILF8wTsLB0jT44qUBV8Ce1SvA9uqcM9Xf+u3fJFBw==}
 
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
@@ -4061,8 +4060,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shiki@1.6.4:
-    resolution: {integrity: sha512-X88chM7w8jnadoZtjPTi5ahCJx9pc9f8GfEkZAEYUTlcUZIEw2D/RY86HI/LkkE7Nj8TQWkiBfaFTJ3VJT6ESg==}
+  shiki@1.9.0:
+    resolution: {integrity: sha512-i6//Lqgn7+7nZA0qVjoYH0085YdNk4MC+tJV4bo+HgjgRMJ0JmkLZzFAuvVioJqLkcGDK5GAMpghZEZkCnwxpQ==}
 
   should-equal@2.0.0:
     resolution: {integrity: sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==}
@@ -5782,7 +5781,7 @@ snapshots:
       js-yaml: 4.1.0
       minimist: 1.2.8
 
-  '@shikijs/core@1.6.4': {}
+  '@shikijs/core@1.9.0': {}
 
   '@sinclair/typebox@0.27.8': {}
 
@@ -9145,9 +9144,9 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shiki@1.6.4:
+  shiki@1.9.0:
     dependencies:
-      '@shikijs/core': 1.6.4
+      '@shikijs/core': 1.9.0
 
   should-equal@2.0.0:
     dependencies:

--- a/src/components/common/CodeBlock.vue
+++ b/src/components/common/CodeBlock.vue
@@ -29,7 +29,7 @@ const props = defineProps({
     default: '',
   },
 })
-const { getHighlighter } = composables.useShiki()
+const { createHighlighter } = composables.useShiki()
 const highlighter = ref<HighlighterCore>()
 
 const getHighlightLanguage = (snippetLang: LanguageCode | null | undefined): string | null | undefined => {
@@ -45,7 +45,7 @@ const highlightedCode = computed(():string => {
 })
 
 onMounted(async ()=> {
-  highlighter.value = await getHighlighter()
+  highlighter.value = await createHighlighter()
 })
 
 </script>

--- a/src/components/spec-document/samples/RequestSample.spec.ts
+++ b/src/components/spec-document/samples/RequestSample.spec.ts
@@ -9,7 +9,7 @@ describe('<RequestSample />', () => {
   it('Should use correct url in the request sample', async () => {
     vi.spyOn(composables, 'useShiki').mockImplementation(() => {
       return {
-        getHighlighter: (): Promise<HighlighterCore> => {
+        createHighlighter: (): Promise<HighlighterCore> => {
           return {
             //@ts-ignore irrelavent for mocking purposes
             codeToHtml: (c: string) => (c),

--- a/src/composables/useShiki.ts
+++ b/src/composables/useShiki.ts
@@ -1,10 +1,10 @@
-import { getHighlighterCore } from 'shiki/core'
+import { createHighlighterCore } from 'shiki/core'
 import type { HighlighterCore } from 'shiki/core'
 
 export default function useShiki() {
 
-  const getHighlighter = async (): Promise<HighlighterCore> => {
-    return await getHighlighterCore({
+  const createHighlighter = async (): Promise<HighlighterCore> => {
+    return await createHighlighterCore({
       themes: [
         import('shiki/themes/material-theme-lighter.mjs'),
         import('shiki/themes/material-theme-palenight.mjs'),
@@ -33,6 +33,6 @@ export default function useShiki() {
   }
 
   return {
-    getHighlighter,
+    createHighlighter,
   }
 }


### PR DESCRIPTION
# Summary

`shiki` exported methods were changed in the `1.9.0` release https://github.com/shikijs/shiki/pull/702