### PR TITLE
fix: minheight for line numbers in code-block [KHCP-12439]

### DIFF
--- a/src/components/common/CodeBlock.vue
+++ b/src/components/common/CodeBlock.vue
@@ -76,8 +76,8 @@ onMounted(async ()=> {
     display: inline-block;
     font-family: var(--kui-font-family-code, $kui-font-family-code);
     font-size: var(--kui-font-size-20, $kui-font-size-20);
+    min-height: 16px; // this is to enforce height on empty line
     min-width: fit-content;
-    min-height: calc(var(--kui-space-50, $kui-space-50) + 2px);
     padding-left: calc(#{$codeblock-line-count-width} + 6px);
     position: relative;
     word-break: break-all;


### PR DESCRIPTION
# Summary

To force height on empty lines: 
before: 
![image](https://github.com/Kong/spec-renderer/assets/4562608/1d34d511-45a5-4264-938a-7d25095ba756)


after: 

![image](https://github.com/Kong/spec-renderer/assets/4562608/115d1be6-7a13-414e-9513-49dd86515654)

