### PR TITLE
fix(body-content-list): resolve schema object before removing readonly fields from it [KHCP-12554]

### DIFF
--- a/src/components/spec-document/endpoint/BodyContentList.vue
+++ b/src/components/spec-document/endpoint/BodyContentList.vue
@@ -63,7 +63,7 @@ import type { IMediaTypeContent } from '@stoplight/types'
 import ModelNode from '../schema-model/ModelNode.vue'
 import CollapsibleSection from './CollapsibleSection.vue'
 import type { SchemaObject } from '@/types'
-import { removeFieldsFromSchemaObject } from '@/utils'
+import { removeFieldsFromSchemaObject, resolveSchemaObjectFields } from '@/utils'
 
 const props = defineProps({
   description: {
@@ -81,7 +81,8 @@ const props = defineProps({
 })
 
 function parseSchema(schema: SchemaObject) {
-  return props.readonlyVisible ? schema : removeFieldsFromSchemaObject(schema)
+  const resolvedSchema = resolveSchemaObjectFields(schema)
+  return props.readonlyVisible ? resolvedSchema : removeFieldsFromSchemaObject(resolvedSchema)
 }
 </script>
 


### PR DESCRIPTION
# Summary

The schema wasn't being resolved (using `resolveSchemaObjectFields`, which also merges allOf) before being passed to `removeFieldsFromSchemaObject` for removing the readOnly fields.
This PR ensures the schema passed to `removeFieldsFromSchemaObject` has allOf merged already.

![image](https://github.com/Kong/spec-renderer/assets/47082523/8e116c52-ecaf-446b-a779-0c4d5c2e8a3e)

