### PR TITLE
fix(headless-popover): add flip middleware [KHCP-12552]

### DIFF
--- a/src/components/common/HeadlessPopover.vue
+++ b/src/components/common/HeadlessPopover.vue
@@ -40,7 +40,7 @@
 <script setup lang="ts">
 import { ref, onMounted, onBeforeUnmount, computed, watch, useAttrs } from 'vue'
 import type { PropType } from 'vue'
-import { useFloating, autoUpdate, offset } from '@floating-ui/vue'
+import { useFloating, autoUpdate, offset, flip } from '@floating-ui/vue'
 import type { Placement } from '@floating-ui/vue'
 import { PopoverPlacementVariants } from '@/types'
 
@@ -174,7 +174,7 @@ const popoverStyles = computed(() => {
 
 const { floatingStyles, update: updatePosition } = useFloating(popoverTrigger, popoverRef, {
   placement: props.placement,
-  middleware: [offset(props.popoverOffset)],
+  middleware: [offset(props.popoverOffset), flip()],
   strategy: 'fixed',
   transform: false,
 })


### PR DESCRIPTION
# Summary

Add `flip` middleware so that dropdown flips instead of colliding with viewport

![Screenshot 2024-07-09 at 4 12 45 PM](https://github.com/Kong/spec-renderer/assets/36751160/c832479a-0645-4fa5-8990-8048b288b326)
![Screenshot 2024-07-09 at 4 13 02 PM](https://github.com/Kong/spec-renderer/assets/36751160/84d5427f-7a91-4843-85c2-6d6189aa1a12)