### PR TITLE
fix: only setCursorPosition when needed [KHCP-12678]

### DIFF
--- a/src/components/common/EditableCodeBlock.vue
+++ b/src/components/common/EditableCodeBlock.vue
@@ -251,7 +251,9 @@ watch(() => ({ code: props.code, lang: props.lang, editableInput: editableInput.
       presentedCode.value = editableCode.value
       if (newEditableInput) {
         newEditableInput.innerText = editableCode.value
-        setCursorPosition(cursorPosition.value, true)
+        if (cursorPosition.value !== 0) {
+          setCursorPosition(cursorPosition.value, true)
+        }
       }
     }
   })


### PR DESCRIPTION
# Summary

This is to prevent making editable code block focusable when not needed. 