### PR TITLE
fix(property-field-list): add overflow-wrap for property fields [KHCP-12740]

### DIFF
--- a/src/components/spec-document/schema-model/PropertyFieldList.vue
+++ b/src/components/spec-document/schema-model/PropertyFieldList.vue
@@ -1,11 +1,13 @@
 <template>
-  <component
-    :is="field.component"
-    v-for="field in orderedFieldList"
-    :key="field.key"
-    v-bind="field.props"
-    v-on="field.eventHandlers"
-  />
+  <div class="property-field-list">
+    <component
+      :is="field.component"
+      v-for="field in orderedFieldList"
+      :key="field.key"
+      v-bind="field.props"
+      v-on="field.eventHandlers"
+    />
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -129,3 +131,12 @@ const orderedFieldList = computed(() => {
   return fields
 })
 </script>
+
+<style lang="scss" scoped>
+.property-field-list {
+  overflow-wrap: anywhere;
+  > :not(:first-child) {
+    margin-top: var(--kui-space-50, $kui-space-50);
+  }
+}
+</style>


### PR DESCRIPTION
# Summary

- add `overflow-wrap: anywhere` for property fields
- wrap `property-field-list` component with a div to apply styling to all property fields

## Previews

### Before

The `example` property field breaks the UI because it would only break when a space was encountered.

<img width="1506" alt="image" src="https://github.com/user-attachments/assets/d965735c-424a-4363-942c-f291f3d10ff2">


### After
<img width="1190" alt="image" src="https://github.com/user-attachments/assets/3eb241f5-7ba2-4e21-9176-b0bcfc15f382">



Jira ticket: https://konghq.atlassian.net/browse/KHCP-12740