### PR TITLE
feat(use-markdown): allow support for all markdown flavours

### DIFF
--- a/src/composables/useMarkdown.ts
+++ b/src/composables/useMarkdown.ts
@@ -8,7 +8,7 @@ export default function useMarkdown() {
 
   function initializeMarkdown() {
     if (!md.value) {
-      md.value = markdownit('commonmark', {
+      md.value = markdownit({
         html: false, // Keep disabled to prevent XSS
         xhtmlOut: true, // Use '/' to close single tags (<br />)
         breaks: true, // Convert '\n' in paragraphs into <br>


### PR DESCRIPTION
# Summary

- remove strict support only for commonmark syntax

## Previews

Tables like 
```md
| first column | second column |
| ------------ | ------------- |
| a            | 1             |
| b            | 2             |
| c            | 3             |
```
will now render correctly. They didn't earlier because CommonMark doesn’t support tables of this syntax.

<img width="307" alt="image" src="https://github.com/user-attachments/assets/3cef75ca-6876-4125-a096-a90d625e22f3">

