### PR TITLE
fix(schema-example): schema example generation bugs [KHCP-12906]

### DIFF
--- a/src/utils/schema-example.ts
+++ b/src/utils/schema-example.ts
@@ -102,6 +102,8 @@ export const crawl = ({ objData, parentKey, nestedLevel, filteringOptions }: Cra
     }
 
     if (oData.type === 'array') {
+      // if it's an array of objects, we'll generate the sample array item by crawling again
+      // else, if there's no inherited fields, we'll generate the sample array item using extractSampleForParam
       sampleObj[key] =
         oData.format === 'object'
           ? [crawl({
@@ -134,6 +136,12 @@ export const crawl = ({ objData, parentKey, nestedLevel, filteringOptions }: Cra
   return sampleObj
 }
 
+/**
+ * util to generate example for inherited fields like allOf, anyOf, oneOf
+ *
+ * @param {CrawlOptions} CrawlOptions
+ * @returns {Record<string, any> | null}
+ */
 const crawlInheritedProperties = ({ objData, parentKey, nestedLevel, filteringOptions }: CrawlOptions): Record<string, any> | null => {
   if (typeof objData === 'undefined') {
     return null


### PR DESCRIPTION
# Summary

- use `nestedLevel + 1` instead of `nestedLevel++`
- fix example generation for inherited fields (oneOf, anyOf, allOf)

## Previews

<img width="1413" alt="image" src="https://github.com/user-attachments/assets/2791f76f-fba5-4f4d-81f9-6168fe704a99">

