### PR TITLE
feat(http-response): show response description in case of empty content-list [KHCP-12881]

### DIFF
--- a/src/components/spec-document/endpoint/HttpResponse.vue
+++ b/src/components/spec-document/endpoint/HttpResponse.vue
@@ -48,9 +48,5 @@ defineProps({
     display: inline-flex;
     gap: var(--kui-space-50, $kui-space-50);
   }
-
-  .http-response-description {
-    margin-top: var(--kui-space-40, $kui-space-40);
-  }
 }
 </style>


### PR DESCRIPTION
# Summary

- render `BodyContentList` even if content-list is empty for a response as description will still be present to display

<img width="1066" alt="image" src="https://github.com/user-attachments/assets/47b2690f-f689-4d81-b4fe-a7da82e177a3">


