### PR TITLE
feat(property-default): add component to show default values [KHCP-13067]

### DIFF
--- a/src/components/spec-document/schema-model/PropertyFieldList.vue
+++ b/src/components/spec-document/schema-model/PropertyFieldList.vue
@@ -22,6 +22,7 @@ import PropertyInfo from './property-fields/PropertyInfo.vue'
 import PropertyEnum from './property-fields/PropertyEnum.vue'
 import PropertyPattern from './property-fields/PropertyPattern.vue'
 import PropertyRange from './property-fields/PropertyRange.vue'
+import PropertyDefault from './property-fields/PropertyDefault.vue'
 
 const props = defineProps({
   property: {
@@ -103,6 +104,17 @@ const orderedFieldList = computed(() => {
       },
       eventHandlers:{},
       key: 'property-pattern',
+    })
+  }
+
+  if (!props.hiddenFieldList.includes('default') && props.property.default !== undefined) {
+    fields.push({
+      component: PropertyDefault,
+      props: {
+        defaultValue: String(props.property.default),
+      },
+      eventHandlers:{},
+      key: 'property-default',
     })
   }
 

--- a/src/components/spec-document/schema-model/property-fields/PropertyDefault.vue
+++ b/src/components/spec-document/schema-model/property-fields/PropertyDefault.vue
@@ -1,0 +1,30 @@
+<template>
+  <p
+    class="property-field-default"
+    data-testid="property-field-default"
+  >
+    <span class="field-title">Default:</span>
+    <span class="property-field-default-value">
+      {{ defaultValue }}
+    </span>
+  </p>
+</template>
+
+<script setup lang="ts">
+defineProps({
+  defaultValue: {
+    type: String,
+    required: true,
+  },
+})
+</script>
+
+<style lang="scss" scoped>
+.property-field-default {
+  @include model-property-additional-field;
+
+  .property-field-default-value {
+    @include model-property-field-value;
+  }
+}
+</style>

--- a/src/types/spec-renderer.ts
+++ b/src/types/spec-renderer.ts
@@ -44,4 +44,4 @@ export interface ParseOptions {
   withCredentials: boolean
 }
 
-export type SchemaModelPropertyField = 'info' | 'description' | 'enum' | 'pattern' | 'range' | 'example'
+export type SchemaModelPropertyField = 'info' | 'description' | 'enum' | 'pattern' | 'range' | 'example' | 'default'


### PR DESCRIPTION
# Summary

Add component to render default value of a schema model or property.

## Preview

<img width="388" alt="image" src="https://github.com/user-attachments/assets/c6f27a98-393d-433b-a3ac-cd5c1c6f31da">
<img width="905" alt="image" src="https://github.com/user-attachments/assets/88ff5be4-89e9-4e03-9a69-b7647ff64712">

