### PR TITLE
fix(schema-model): merge fields correctly for array schema objects [KHCP-13003]

### DIFF
--- a/src/utils/schema-model.spec.ts
+++ b/src/utils/schema-model.spec.ts
@@ -73,6 +73,33 @@ describe('resolveSchemaObjectFields', () => {
     expect(resolveSchemaObjectFields(schemaObject)?.properties).toEqual(itemProperties)
     expect(resolveSchemaObjectFields(schemaObject)?.required).toEqual(itemRequiredFields)
   })
+  it('merges items and properties of a Schema Object of type array correctly', () => {
+    // fields under items
+    const itemProperties: Record<string, SchemaObject> = {
+      name: {
+        type: 'string',
+      },
+    }
+    const itemRequiredFields = ['name']
+
+    // fields directly under the schema object
+    const schemaDescription = 'Example description'
+
+    const schemaObject: SchemaObject = {
+      type: 'array',
+      description: schemaDescription,
+      readOnly: true,
+      items: {
+        type: 'object',
+        properties: itemProperties,
+        required: itemRequiredFields,
+      },
+    }
+    expect(resolveSchemaObjectFields(schemaObject)?.properties).toEqual(itemProperties)
+    expect(resolveSchemaObjectFields(schemaObject)?.required).toEqual(itemRequiredFields)
+    expect(resolveSchemaObjectFields(schemaObject)?.description).toEqual(schemaDescription)
+    expect(resolveSchemaObjectFields(schemaObject)?.readOnly).toEqual(true)
+  })
   it('returns empty objects for invalid Schema Object', () => {
     const invalidSchemaObjectList = [
       [{

--- a/src/utils/schema-model.ts
+++ b/src/utils/schema-model.ts
@@ -49,7 +49,16 @@ export const resolveSchemaObjectFields = (candidate: unknown): SchemaObject => {
   */
   if (candidate.type === 'array' && candidate.items) {
     if (isValidSchemaObject(candidate.items)) {
-      return { ...resolveAllOf(candidate.items), type: 'array', format: candidate.items.type?.toString() }
+      /**
+       * we need —
+       * - fields listed directly under the model, except items
+       * - fields listed under items, so we destructure items
+       * - data type as 'array' and format as the array item data type
+       * if a field is present in both items and the model itself, we use the one from items
+       */
+      const candidateWithoutItems = { ...candidate }
+      delete candidateWithoutItems.items
+      return { ...candidateWithoutItems, ...resolveAllOf(candidate.items), type: 'array', format: candidate.items.type?.toString() }
     } else {
       return {}
     }


### PR DESCRIPTION
# Summary

Array schema objects can have fields defined at 2 levels:
- directly under the schema object itself
- under the `items` property. The `items` property is also a Schema Object so it can have all the same fields like enum, default, example, etc.

e.g.
```json
{
  "type": "array",
  "description": "Sample Array",
  "default": "second",
  "enum": [
    "first",
    "second",
    "third"
  ],
  "items": {
    "type": "string",
    "default": "first"
  }
}
```

So we need to correctly merge fields directly under the schema object and those under the `items` property.

Rules for merging:

> we need —
> - fields listed directly under the model, except `items`
> - fields listed under `items` property
> - data type as 'array' and format as the array item data type
>
> if a field is present in both items and the model itself, we use the one from items

e.g.
<img width="1037" alt="image" src="https://github.com/user-attachments/assets/d7000ce4-86c0-439a-997a-7736063e7ef9">


