### PR TITLE
fix(headlesspopover): remove fixed strategy

### DIFF
--- a/src/components/common/HeadlessPopover.vue
+++ b/src/components/common/HeadlessPopover.vue
@@ -175,7 +175,6 @@ const popoverStyles = computed(() => {
 const { floatingStyles } = useFloating(popoverTrigger, popoverRef, {
   placement: props.placement,
   middleware: [offset(props.popoverOffset), flip()],
-  strategy: 'fixed',
   transform: false,
   whileElementsMounted: autoUpdate,
 })


### PR DESCRIPTION
# Summary

Fixes HeadlessPopover placement issue that was introduced with Chrome update to v129

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
