### PR TITLE
fix(schema-renderer): hide example from `property-field-list` if `exampleVisible` is false

### DIFF
--- a/sandbox/pages/ComponentsPlayground.vue
+++ b/sandbox/pages/ComponentsPlayground.vue
@@ -124,6 +124,12 @@ const schema = {
   'description': "I'm a model's description.",
   'type': 'object',
   'title': 'Todo',
+  'example': {
+    'id': 1,
+    'name': 'Buy milk',
+    'completed': true,
+    'completed_at': '2021-01-01T00:00:00.000Z',
+  },
   'properties': {
     'id': {
       'type': 'number',

--- a/src/components/extra-renderers/SchemaRenderer.vue
+++ b/src/components/extra-renderers/SchemaRenderer.vue
@@ -117,8 +117,13 @@ const exampleModel = computed(() => {
   return crawledExample && Object.keys(crawledExample).length ? JSON.stringify(crawledExample, null, CODE_INDENT_SPACES) : ''
 })
 
+/**
+ * list of fields to hide from the property field list
+ * - info and description fields are always hidden
+ * - example field is hidden when exampleVisible prop is false or exampleModel is rendered inside the example section
+ */
 const hiddenFieldList = computed<Array<SchemaModelPropertyField>>(() =>
-  exampleModel.value
+  exampleModel.value || !showExample.value
     ? ['info', 'description', 'example']
     : ['info', 'description'],
 )


### PR DESCRIPTION
# Summary

`property-field-list` renders all the schema properties like enum, default value, range, etc.
It also shows the schema example in case we're not showing the example section.

However, this behavior should respect the `exampleVisible` prop.

<img width="1245" alt="image" src="https://github.com/user-attachments/assets/07e533af-8ff9-4cb4-96ad-a29adfad5a33">

