### PR TITLE
Using token for code block background

### DIFF
--- a/src/components/common/CodeBlock.vue
+++ b/src/components/common/CodeBlock.vue
@@ -46,7 +46,7 @@ const highlightedCode = computed(():string => {
   :deep(pre) {
     @include pre;
 
-    background: var(--kui-color-background-primary-weaker, $kui-color-background-neutral-weaker) !important;
+    background: var(--kui-color-background-neutral-weaker, $kui-color-background-neutral-weaker) !important;
     border: none;
     border-radius: var(--kui-border-radius-0, $kui-border-radius-0);
     font-size: var(--kui-font-size-20, $kui-font-size-20);


### PR DESCRIPTION
# Summary

closest matching token is still to dark, so keep this in draft 
## before 

![image](https://github.com/user-attachments/assets/f7d78638-ecc0-4856-91e0-9da65a1ba825)


# after 

![image](https://github.com/user-attachments/assets/05398c21-e7ea-411c-94c5-72a13f393656)
