### PR TITLE
test: add toc data-testids

### DIFF
--- a/src/components/spec-renderer-toc/GroupItem.vue
+++ b/src/components/spec-renderer-toc/GroupItem.vue
@@ -2,12 +2,14 @@
   <li
     class="group-item"
     :class="{ root: root }"
+    data-testid="group-item"
   >
     <button
       v-if="!item.hideTitle"
       ref="collapseTriggerRef"
       :aria-controls="collapseGroupId"
       :aria-expanded="isExpanded"
+      data-testid="group-item-button"
       type="button"
       @click="onClick"
     >
@@ -23,6 +25,7 @@
       <ul
         v-show="isExpanded"
         :id="collapseGroupId"
+        data-testid="group-item-list"
       >
         <component
           :is="itemComponent(child)"

--- a/src/components/spec-renderer-toc/NodeItem.vue
+++ b/src/components/spec-renderer-toc/NodeItem.vue
@@ -2,9 +2,11 @@
   <li
     class="node-item"
     :data-spec-renderer-toc-active="isActive ? true : undefined"
+    data-testid="node-item"
   >
     <a
       :class="{ 'single-word': isSingleWord, 'active': isActive }"
+      data-testid="node-item-title-link"
       :href="`${basePath}${navigationType==='hash' ? '#' : ''}${item.id}`"
       :title="itemTitle"
       @click.prevent="selectItem(item.id)"
@@ -12,6 +14,7 @@
       <span
         class="node-item-title"
         :class="{ 'deprecated-node-item': item.deprecated }"
+        data-testid="node-item-title"
       >
         {{ item.title }}
       </span>
@@ -19,6 +22,7 @@
       <MethodBadge
         v-if="item.type === NodeType.HttpOperation || item.type === NodeType.HttpWebhook"
         class="http-operation-badge"
+        data-testid="http-operation-badge"
         :inverted="isActive"
         :method="item.meta"
       />

--- a/src/components/spec-renderer-toc/SpecRendererToc.vue
+++ b/src/components/spec-renderer-toc/SpecRendererToc.vue
@@ -2,6 +2,7 @@
   <nav
     ref="tocNavRef"
     class="table-of-contents"
+    data-testid="table-of-contents"
   >
     <ul>
       <component


### PR DESCRIPTION
# Summary

Add some `data-testid` selectors within the sidebar to make writing some e2e coverage in the host app easier. These can be used internally to also provide additional coverage, so no adverse impact.