### PR TITLE
feat(try-it): add loading state to try-it button

### DIFF
--- a/src/components/spec-document/try-it/TryIt.vue
+++ b/src/components/spec-document/try-it/TryIt.vue
@@ -20,6 +20,7 @@
         v-if="data.path"
         class="tryit-button-dropdown"
         :data="data"
+        :is-loading="apiCallLoading"
         @tryit-api-call="doApiCall"
       />
     </div>
@@ -129,6 +130,8 @@ const currentRequestHeaders = ref<Array<Record<string, string>>>([])
 
 const currentRequestBody = ref<string>('')
 
+const apiCallLoading = ref(false)
+
 // hide body section if none of the params are present
 const sectionBodyEmpty = computed((): boolean =>
   (!props.data.servers || !props.data.servers.some(s => s.variables)) &&
@@ -165,6 +168,7 @@ const hideTryIt = inject<Ref<boolean>>('hide-tryit', ref(false))
 
 const doApiCall = async () => {
   try {
+    apiCallLoading.value = true
     response.value = undefined
     const url = new URL(`${currentServerUrl.value}${currentRequestPath.value}`.replaceAll('{', '').replaceAll('}', ''))
     let queryStr = currentRequestQuery.value
@@ -187,6 +191,8 @@ const doApiCall = async () => {
     })
   } catch (error: any) {
     responseError.value = error
+  } finally {
+    apiCallLoading.value = false
   }
 }
 

--- a/src/components/spec-document/try-it/TryItDropdown.vue
+++ b/src/components/spec-document/try-it/TryItDropdown.vue
@@ -7,10 +7,11 @@
       class="call-button"
       :class="{ 'no-dropdown': !showInsomnia }"
       :data-testid="`tryit-call-button-${data.id}`"
+      :disabled="isLoading"
       @click="startApiCall"
     >
       <component
-        :is="selectedTryItMethodKey === 'browser' ? NetworkIcon : InsomniaIcon"
+        :is="tryItIcon"
         v-if="showInsomnia"
         class="tryit-method-icon"
       />
@@ -22,6 +23,7 @@
       :id="`tryit-dropdown-${data.id}`"
       class="tryit-dropdown"
       :data-testid="`tryit-dropdown-${data.id}`"
+      :disabled="isLoading"
       :items="items"
       placement="bottom-end"
       trigger-button=""
@@ -54,13 +56,17 @@ import type { PropType, Ref } from 'vue'
 import type { IHttpOperation } from '@stoplight/types'
 import SelectDropdown from '@/components/common/SelectDropdown.vue'
 import type { SelectItem } from '@/types'
-import { NetworkIcon, InsomniaIcon } from '@kong/icons'
+import { NetworkIcon, InsomniaIcon, ProgressIcon } from '@kong/icons'
 import composables from '@/composables'
 
-defineProps({
+const props = defineProps({
   data: {
     type: Object as PropType<IHttpOperation>,
     required: true,
+  },
+  isLoading: {
+    type: Boolean,
+    default: false,
   },
 })
 
@@ -88,6 +94,14 @@ const specUrl = inject<Ref<string>>('spec-url', ref(''))
 // when property forced or url of the specification is not provided
 const showInsomnia = computed((): boolean => {
   return !(hideInsomniaTryIt.value || !specUrl.value)
+})
+
+const tryItIcon = computed(() => {
+  if (props.isLoading) {
+    return ProgressIcon
+  }
+
+  return selectedTryItMethodKey.value === 'browser' ? NetworkIcon : InsomniaIcon
 })
 
 const { selectedTryItMethodKey } = composables.useTryItState()
@@ -124,6 +138,13 @@ const selectionChanged = (item: SelectItem) => {
     &:active {
       background-color: $hoverBg;
     }
+
+    &:disabled, &[disabled] {
+      background-color: var(--kui-color-background-transparent, $kui-color-background-transparent);
+      border-color: var(--kui-color-border-disabled, $kui-color-border-disabled);
+      color: var(--kui-color-text-disabled, $kui-color-text-disabled);
+      cursor: not-allowed;
+    }
   }
 
   .tryit-dropdown {
@@ -139,6 +160,17 @@ const selectionChanged = (item: SelectItem) => {
       &:active {
         background-color: $hoverBg !important;
         color: $textColor !important;
+      }
+
+      &:disabled, &[disabled] {
+        background-color: var(--kui-color-background-transparent, $kui-color-background-transparent);
+        border-color: var(--kui-color-border-disabled, $kui-color-border-disabled);
+        color: var(--kui-color-text-disabled, $kui-color-text-disabled);
+        cursor: not-allowed;
+
+        .select-chevron-icon {
+          color: var(--kui-color-text-disabled, $kui-color-text-disabled) !important;
+        }
       }
     }
   }


### PR DESCRIPTION
# Summary

This PR adds loading state to the try-it button. Loading state is only triggered if an API call is made inside the browser, not for the insomnia try-it.

# Preview


<img width="119" alt="image" src="https://github.com/user-attachments/assets/7ae20640-1ff1-4bc6-9cc2-500bef9863b1" />


https://github.com/user-attachments/assets/8883c490-6a5a-4305-ba23-4dede90ea1cd


https://github.com/user-attachments/assets/59e32cbd-b2f4-4bf0-a09b-41861893ce55

