### PR TITLE
fix(try-it): show loading icon also when insomnia button is hidden

### DIFF
--- a/src/components/spec-document/try-it/TryItDropdown.vue
+++ b/src/components/spec-document/try-it/TryItDropdown.vue
@@ -12,7 +12,7 @@
     >
       <component
         :is="tryItIcon"
-        v-if="showInsomnia"
+        v-if="tryItIcon"
         class="tryit-method-icon"
       />
       Try It!
@@ -99,6 +99,10 @@ const showInsomnia = computed((): boolean => {
 const tryItIcon = computed(() => {
   if (props.isLoading) {
     return ProgressIcon
+  }
+
+  if (!showInsomnia.value) {
+    return null
   }
 
   return selectedTryItMethodKey.value === 'browser' ? NetworkIcon : InsomniaIcon
@@ -285,6 +289,7 @@ const selectionChanged = (item: SelectItem) => {
   }
 
   .tryit-method-icon {
+    height: var(--kui-icon-size-40, $kui-icon-size-40) !important;
     width: var(--kui-icon-size-40, $kui-icon-size-40) !important;
   }
 }


### PR DESCRIPTION
# Summary

#449 added loading state to try-it button.
This PR ensures that we show the same loading state even when insomnia option is unavailable in try-out (in which case we don't show a menu).

# Preview

## Insomnia option unavailable

https://github.com/user-attachments/assets/1448a1da-097f-4f80-9759-d26e11fff8f4

## Insomnia option available


https://github.com/user-attachments/assets/f7972f83-d43f-4257-a8b7-539546d50d4d


