### PR TITLE
fix: unexpected scrolling jump [KHCP-14793]

### DIFF
--- a/src/components/spec-document/SpecDocument.vue
+++ b/src/components/spec-document/SpecDocument.vue
@@ -387,7 +387,6 @@ watch(() => ({ nodesList: nodesList.value,
     && Math.abs(newValue.yPosition - lastY.value) < MIN_SCROLL_DIFFERENCE) {
     return
   }
-
   const visibleEls:Array<Record<string, any>> = []
   const visibleIndexes: Array<number> = []
   Array.from(newValue.wrapperRef.children).forEach((c, i) => {
@@ -440,7 +439,6 @@ watch(() => ({ nodesList: nodesList.value,
 watch(() => ({
   pathname: props.currentPath,
   document: specDocument.value }), async (newValue, oldValue) => {
-
 
   const { pathname, document: newDocument } = newValue
   const { document: oldDocument } = oldValue || {}
@@ -524,8 +522,6 @@ watch(() => ({
 onBeforeMount(async () => {
   await createHighlighter()
 })
-
-
 
 </script>
 


### PR DESCRIPTION
# Summary

Issue: 

When you scroll trough content, right after TOC for the specific operation becomes active, it jumps on top of the container, which it should not.  (this is reproducible in portal only).

Before the fix: 
https://github.com/user-attachments/assets/b59371bf-a48f-495c-941c-6675f2882002

After the fix: 

https://github.com/user-attachments/assets/95310810-4b90-423b-bf20-cc16a8e6d0f0




