### PR TITLE
feat: add support for image type response [KHCP-14956]

### DIFF
--- a/sandbox/components/SampleSpecSelector.vue
+++ b/sandbox/components/SampleSpecSelector.vue
@@ -107,6 +107,7 @@ const optionsArrayOAS = [
   { url: 'https://raw.githubusercontent.com/stoplightio/Public-APIs/master/reference/netlify/openapi.yaml', label: 'Netlify' },
   { url: 'https://api.apis.guru/v2/specs/instagram.com/1.0.0/swagger.yaml', label: 'Instagram' },
   { url: 'https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json', label: 'Stripe' },
+  { url: 'https://httpbin.org/spec.json', label: 'Httpbin' },
 ]
 
 


### PR DESCRIPTION
# Summary

We supported text and JSON type responses. This PR adds support for image responses too.
Also added the Httpbin spec to sample specs.

Resolves: https://konghq.atlassian.net/browse/KHCP-14956

# Preview

https://github.com/user-attachments/assets/37cb0fda-719b-4a55-815a-211a7aefda2b

## Image response

<img width="933" alt="image" src="https://github.com/user-attachments/assets/ba5cb2f0-ed60-4162-bb16-5118dddec629" />

## JSON response

<img width="930" alt="image" src="https://github.com/user-attachments/assets/7e8ab899-a8ed-4c96-a52a-cd286f1b1baf" />

## Text response

<img width="933" alt="image" src="https://github.com/user-attachments/assets/63363fd2-3739-4302-a921-95325623bbb3" />

<img width="935" alt="image" src="https://github.com/user-attachments/assets/cabaff0f-58c3-4fbb-a2c9-7dbf40a6b952" />

