### PR TITLE
fix(server-list): show add custom url button if no server url present

### DIFF
--- a/src/components/spec-document/HttpService.vue
+++ b/src/components/spec-document/HttpService.vue
@@ -22,7 +22,6 @@
         :markdown="data.description"
       />
       <ServerList
-        v-if="serverList.length"
         :server-list="serverList"
         @add-custom-url="addServerUrl"
       />

--- a/src/composables/useServerList.ts
+++ b/src/composables/useServerList.ts
@@ -32,14 +32,16 @@ export default function useServerList() {
   }
 
   /**
-   * Add a new server to the list of servers in the state.
-   * Also generates a unique ID for the server, based on its index in the list.
+   * Add a new server to the list of servers in the state and generates a unique ID for the server, based on its index in the list.
+   * Also sets the selected server URL to the newly added server URL.
    */
   const addServerUrl = (newServerUrl: string) => {
+    const url = removeTrailingSlash(newServerUrl)
     serverList.value.push({
       id: serverList.value.length.toString(),
-      url: removeTrailingSlash(newServerUrl),
+      url,
     })
+    selectedServerUrl.value = url
   }
 
   /**


### PR DESCRIPTION
# Summary

- if no server URL are present in a spec, we now show the "Add custom URL" button in the "API Base URL" (server endpoints) section.
- if user adds a custom URL, it is automatically set as the selected server URL for all endpoints


# Preview

<img width="1507" alt="image" src="https://github.com/user-attachments/assets/1ffe927d-12a0-4c18-a765-d6f3c13d4276" />


https://github.com/user-attachments/assets/971d238b-868b-418e-8d13-b802afcd59d1

