### PR TITLE
fix: show operation in portal when opened via NuxRouter from search [KHCP-15336]

### DIFF
--- a/src/components/spec-document/SpecDocument.vue
+++ b/src/components/spec-document/SpecDocument.vue
@@ -573,7 +573,7 @@ watch(() => ({
   if (document) {
     if (!wrapperRef.value) {
       // KHCP-15336 there is a case in portal when wrapperRef is not initialised at this pont
-      await until(wrapperRef).not.toBeNull({timeout: 10000})
+      await until(wrapperRef).not.toBeNull({ timeout: 10000 })
     }
     const activeSectionEl = wrapperRef.value?.querySelector(`[id="${pathIdx}-nodecontainer"]`)
 


### PR DESCRIPTION
# Summary

repro and validation in [KHCP-15336](https://konghq.atlassian.net/browse/KHCP-15336)

[KHCP-15336]: https://konghq.atlassian.net/browse/KHCP-15336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ