### PR TITLE
feat(schema-renderer): add support for scrolling into view nested fields [KHCP-15281]

### DIFF
--- a/sandbox/pages/ComponentsPlayground.vue
+++ b/sandbox/pages/ComponentsPlayground.vue
@@ -89,7 +89,7 @@
         enable-property-links
         :example-visible="false"
         :header-visible="true"
-        :schema="schema"
+        :schema="sampleSchema"
         title="Sample Schema"
       />
     </div>
@@ -105,6 +105,7 @@ import SelectDropdown from '../../src/components/common/SelectDropdown.vue'
 import { KongIcon } from '@kong/icons'
 import SlideOut from '../../src/components/common/SlideOut.vue'
 import SchemaRenderer from '../../src/components/extra-renderers/SchemaRenderer.vue'
+import sampleSchema from '../sample-schema.json'
 
 const dropdownItems = [
   { label: 'Item 1', value: 'item-1' },
@@ -120,113 +121,6 @@ const onDropdownButtonClick = () => {
 const toggle = ref<boolean>(false)
 
 const isSlideoutOpen = ref<boolean>(false)
-
-const schema = {
-  'description': "I'm a model's description.",
-  'type': 'object',
-  'title': 'Todo',
-  'example': {
-    'id': 1,
-    'name': 'Buy milk',
-    'completed': true,
-    'completed_at': '2021-01-01T00:00:00.000Z',
-  },
-  'properties': {
-    'id': {
-      'type': 'number',
-      'minimum': 0,
-      'maximum': 9999,
-      'description': 'ID of the task',
-      'readOnly': true,
-    },
-    'name': {
-      'type': 'string',
-      'minLength': 1,
-      'maxLength': 100,
-      'description': 'Name of the task',
-    },
-    'completed': {
-      'type': 'boolean',
-      'default': false,
-      'description': 'Boolean indicating if the task has been completed or not',
-    },
-    'completed_at': {
-      'type': 'string',
-      'format': 'date-time',
-      'description': 'Time when the task was completed',
-      'readOnly': true,
-    },
-    'created_at': {
-      'type': 'string',
-      'format': 'date-time',
-      'description': 'Time when the task was created',
-      'readOnly': true,
-    },
-    'updated_at': {
-      'type': 'string',
-      'format': 'date-time',
-      'description': 'Time when the task was updated',
-      'readOnly': true,
-    },
-    'userId': {
-      'type': 'number',
-      'description': 'ID of the user',
-      'readOnly': true,
-    },
-    'firstName': {
-      'type': 'string',
-      'minLength': 1,
-      'description': '',
-    },
-    'lastName': {
-      'type': 'string',
-      'minLength': 1,
-      'description': '',
-    },
-    'phoneNumber': {
-      'type': 'string',
-      'minLength': 1,
-      'description': 'Official Phone Number',
-    },
-    'emailAddress': {
-      'type': 'string',
-      'minLength': 1,
-      'description': 'Work Email Address',
-    },
-    'address': {
-      'type': 'object',
-      'properties': {
-        'street': {
-          'type': 'string',
-          'minLength': 1,
-          'description': 'Street address',
-        },
-        'city': {
-          'type': 'string',
-          'minLength': 1,
-          'description': 'City',
-        },
-        'state': {
-          'type': 'string',
-          'minLength': 1,
-          'description': 'State',
-        },
-        'zip': {
-          'type': 'string',
-          'minLength': 1,
-          'description': 'Zip code',
-        },
-      },
-    },
-  },
-  'required': [
-    'id',
-    'name',
-    'completed_at',
-    'created_at',
-    'updated_at',
-  ],
-}
 </script>
 
 <style lang="scss" scoped>

--- a/sandbox/sample-schema.json
+++ b/sandbox/sample-schema.json
@@ -1,0 +1,117 @@
+{
+  "description": "I'm a model's description.",
+  "type": "object",
+  "title": "Todo",
+  "example": {
+    "id": 1,
+    "name": "Buy milk",
+    "completed": true,
+    "completed_at": "2021-01-01T00: 00: 00.000Z"
+  },
+  "properties": {
+    "id": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 9999,
+      "description": "ID of the task",
+      "readOnly": true
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 100,
+      "description": "Name of the task"
+    },
+    "completed": {
+      "type": "boolean",
+      "default": false,
+      "description": "Boolean indicating if the task has been completed or not"
+    },
+    "completed_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Time when the task was completed",
+      "readOnly": true
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Time when the task was created",
+      "readOnly": true
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Time when the task was updated",
+      "readOnly": true
+    },
+    "userId": {
+      "type": "number",
+      "description": "ID of the user",
+      "readOnly": true
+    },
+    "firstName": {
+      "type": "string",
+      "minLength": 1,
+      "description": ""
+    },
+    "lastName": {
+      "type": "string",
+      "minLength": 1,
+      "description": ""
+    },
+    "phoneNumber": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Official Phone Number"
+    },
+    "emailAddress": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Work Email Address"
+    },
+    "address": {
+      "type": "object",
+      "properties": {
+        "street": {
+          "type": "object",
+          "description": "Street address",
+          "properties": {
+            "number": {
+              "type": "number",
+              "minLength": 1,
+              "description": "Street number"
+            },
+            "name": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Street name"
+            }
+          }
+        },
+        "city": {
+          "type": "object",
+          "description": "City",
+          "properties": {
+            "name": {
+              "type": "string",
+              "minLength": 1,
+              "description": "City name"
+            }
+          }
+        },
+        "state": {
+          "type": "string",
+          "minLength": 1,
+          "description": "State"
+        },
+        "zip": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Zip code"
+        }
+      }
+    }
+  },
+  "required": ["id", "name", "completed_at", "created_at", "updated_at"]
+}

--- a/src/components/spec-document/schema-model/ModelProperty.vue
+++ b/src/components/spec-document/schema-model/ModelProperty.vue
@@ -1,8 +1,8 @@
 <template>
   <div
     :id="propertyId"
-    class="model-property"
     ref="model-property"
+    class="model-property"
     :data-testid="dataTestId"
   >
     <PropertyFieldList


### PR DESCRIPTION
# Summary

Add support for automatically collapsing nested fields if a deeply nested property was permalinked.

- `ModelProperty` component
    - expand nested child properties if the current property is a parent property
    - if the current proeprty is the one that's permalinked, then scroll it into view
- export sample schema JSON for playground to a separate JSON file

Jira ticket: https://konghq.atlassian.net/browse/KHCP-15281
Preview URL: https://deploy-preview-679--kongdeveloper.netlify.app/plugins/ai-proxy/reference/#schema--config-model-options-huggingface-use-cache

# Preview

https://github.com/user-attachments/assets/e1b37143-76d4-4f78-9c32-1cdc97dc681e




