### PR TITLE
fix(server-endpoint): wrap single server url on overflow [KHCP-15481]

### DIFF
--- a/src/components/spec-document/endpoint/ServerEndpoint.vue
+++ b/src/components/spec-document/endpoint/ServerEndpoint.vue
@@ -134,6 +134,7 @@ const selectItems = computed(() => props.serverUrlList.map((url) => ({ label: ur
       display: flex;
       font-family: var(--kui-font-family-code, $kui-font-family-code);
       gap: var(--kui-space-20, $kui-space-20);
+      overflow-wrap: anywhere;
     }
 
     .endpoint-body {


### PR DESCRIPTION
# Summary

We already wrap the endpoint component when multiple servers are present:

<img width="315" alt="image" src="https://github.com/user-attachments/assets/9476c819-906e-4143-ac7b-90f44755ea78" />

So doing the same for the case when there's only one server URL present:

<img width="315" alt="image" src="https://github.com/user-attachments/assets/df34cfc0-b3f1-442b-82b3-ec295bf44740" />
