### PR TITLE
fix: do not replace first selected Item during scrolling [TDX-5588]

### DIFF
--- a/src/components/spec-document/SpecDocument.vue
+++ b/src/components/spec-document/SpecDocument.vue
@@ -503,7 +503,7 @@ watch(() => ({ nodesList: nodesList.value,
     if (props.controlAddressBar) {
     // we only have path and hash for now
       const newPath = props.navigationType === 'path' ? props.basePath + newUri : props.basePath + '#' + newUri
-      window.history[scrolledItemsCounter.value++ > 0  ? 'replaceState' : 'pushState']({}, '', newPath)
+      window.history[scrolledItemsCounter.value++ > 0 ? 'replaceState' : 'pushState']({}, '', newPath)
     }
     lastPath.value = newUri
   }


### PR DESCRIPTION
# Summary

We need to keep first selected item in history and start replacing starting with the second scrolled one... 
