### PR TITLE
fix: ignore error in titleResolve [TDX-5744]

### DIFF
--- a/src/composables/useSchemaParser.ts
+++ b/src/composables/useSchemaParser.ts
@@ -91,7 +91,7 @@ export default (): {
             }
           }
         } catch (err) {
-          console.warn('Issue in titleResolve:', err)
+          console.warn('@kong/spec-renderer: Issue in titleResolve:', err)
         }
       })
       return fragment


### PR DESCRIPTION
# Summary

- Handle the case when resolvedRef is string in titleResolve. 
- Ignore other Error inside of titleResolve. No error in titleResolve should prevent spec from being rendered. 
