### PR TITLE
fix: do not emit content-scrolling while still in scrolling mode [TDX-5748]

### DIFF
--- a/src/components/spec-document/SpecDocument.vue
+++ b/src/components/spec-document/SpecDocument.vue
@@ -475,11 +475,9 @@ watch(() => ({ nodesList: nodesList.value,
   if (oldValue?.wHeight !== newValue.wHeight || oldValue?.wWidth != newValue.wWidth ) {
     lastY.value = undefined
   }
-  console.log({ yPosition:newValue.yPosition, isScrolling: newValue.isScrolling })
 
   if ( newValue.isScrolling && lastY.value != undefined
     && Math.abs(newValue.yPosition - lastY.value) < MIN_SCROLL_DIFFERENCE) {
-    console.log('return due min-scroll-diff')
     return
   }
 


### PR DESCRIPTION
# Summary

The event `content-scrolled` was emitted too often while content was still scrolled (scrollbar dragged or press-and hold). This was causing sporadic route changes in portal and caused page jump back to unpredicted route. 

Fix: we only want to emit this event when we know that user is done with the scrolling.

## Before

https://github.com/user-attachments/assets/890f04ab-9acc-4e02-985d-b4e484b28254


## after


https://github.com/user-attachments/assets/104835a2-aa8c-4930-aa4d-81fde1cf981d



## consuming

[portal](https://github.com/Kong/portal/pull/1095)
[konnect-ui-apps](https://github.com/Kong/konnect-ui-apps/pull/6758)