### PR TITLE
fix(try-it): use uppercase http method [TDX-5825]

### DIFF
--- a/src/components/spec-document/try-it/TryIt.spec.ts
+++ b/src/components/spec-document/try-it/TryIt.spec.ts
@@ -31,7 +31,7 @@ describe('<TryIt />', () => {
       headers: {
         'Content-Type': 'application/json',
       },
-      method: 'get',
+      method: 'GET',
     })
   })
 

--- a/src/components/spec-document/try-it/TryIt.vue
+++ b/src/components/spec-document/try-it/TryIt.vue
@@ -176,7 +176,7 @@ const doApiCall = async () => {
 
     url.search = queryStr
     response.value = await fetch(url, {
-      method: props.data.method,
+      method: String(props.data.method).toUpperCase(),
       headers: [
         ...(authHeaders?.value || []),
         ...getRequestHeaders(props.data),


### PR DESCRIPTION
# Summary

Convert endpoint method to uppercase when making `fetch` call in try-it

# Preview

https://github.com/user-attachments/assets/34c02894-37c4-4696-91b6-7334ce453f99

