### PR TITLE
fix: rolling back auth header name [TDX-5925]

### DIFF
--- a/src/components/spec-document/try-it/TryItAuth.vue
+++ b/src/components/spec-document/try-it/TryItAuth.vue
@@ -113,7 +113,7 @@ const updateAuthTokens = useDebounceFn(() => {
       const tokenValue = tokenValueMap.value[schemeKey] ?? ''
 
       // @ts-ignore `name` is valid attribute of the schema
-      const schemeName = scheme.name ?? scheme.scheme ?? schemeKey
+      const schemeName = scheme.name
       // @ts-ignore `in` is valid attribute of the schema
       const schemeIn = scheme.in
       // @ts-ignore `scheme` is valid attribute of the schema


### PR DESCRIPTION
# Summary

Need to rollback the change from https://github.com/Kong/spec-renderer/pull/595/files#diff-ebb06a186ebdf2adf86fbf97848209912a8b4a257fd0a8b5d9ef7a7982a55d43R116 as it's breaking a basic Auth. 