### PR TITLE
fix: handle double headers [TDX-5990]

### DIFF
--- a/src/components/spec-document/samples/RequestSample.vue
+++ b/src/components/spec-document/samples/RequestSample.vue
@@ -282,9 +282,9 @@ watch(() => ({
         method: newValue.method.toUpperCase(),
         url: serverUrl.toString(),
         headers: [
-          ...newValue.authHeaders,
           ...getRequestHeaders(props.data),
           ...newValue.customHeaders,
+          ...newValue.authHeaders,
         ],
         postData: {
           mimeType: 'application/json',

--- a/src/components/spec-document/try-it/TryIt.vue
+++ b/src/components/spec-document/try-it/TryIt.vue
@@ -115,7 +115,8 @@ const { activeSecurityScheme, authHeaderMap, authQueryMap } = composables.useAut
 const authHeaders = computed(() => authHeaderMap.value[activeSecurityScheme.value] ?? [])
 const authQuery = computed(() => authQueryMap.value[activeSecurityScheme.value] ?? '')
 
-const authHeaderNameList = ref<Array<string>>([])
+
+const authHeaderNameList = computed(() => authHeaders.value?.map(({ name }) => name) ?? [])
 
 const response = ref<Response | undefined>()
 const responseError = ref<Error>()
@@ -183,9 +184,9 @@ const doApiCall = async (callAsIs = false) => {
 
     url.search = queryStr
     const headers = [
-      ...(authHeaders?.value || []),
       ...getRequestHeaders(props.data),
       ...currentRequestHeaders.value,
+      ...(authHeaders?.value || []),
     ].reduce((acc, current) => {
       acc[ callAsIs === false && isGet ? current.name.toLowerCase() : current.name ] = current.value; return acc
     }, {})
@@ -228,11 +229,10 @@ watch(() => props.requestBody, (body) => {
   currentRequestBody.value = body
 }, { immediate: true })
 
-watch(() => (props.data.id), () => {
-  authHeaderNameList.value = authHeaders.value?.map(({ name }) => name) ?? []
+watch(() => ({ id: props.data.id, authHeaderNameList: authHeaderNameList.value }), (newValue: any) => {
   currentRequestPath.value = getSamplePath(props.data)
   currentRequestQuery.value = getSampleQuery(props.data)
-  currentRequestHeaders.value = getSampleHeaders({ data: props.data, excludeHeaderList: authHeaderNameList.value })
+  currentRequestHeaders.value = getSampleHeaders({ data: props.data, excludeHeaderList: newValue.authHeaderNameList })
   response.value = undefined
   responseError.value = undefined
 }, { immediate: true })


### PR DESCRIPTION
# Summary

There are two issues fixed there: 

1. In `TryIt.vue`, where we are calling `getSampleHeaders` we call it before `excludeHeaderList` is fully populated, and do not watch for change in excludeHeaderList. Therefore randomly we have Authorization header is both authentication and request headers. Fix: watch for `excludeHeaderList` change and when changed - call `getSampleHeaders` 

2. Our logic is  excluding Authorization header from the request headers, but yet when we are rendering Request Sample, or performing actual TruIt fetch, we make requestHeaders win over Authorization headers. Should be opposite - as user is only allowed tho change Authorization header, it should be used in fetch and request sample. 

Both of those are discussed in https://kongstrong.slack.com/archives/CAW1MAFLZ/p1750111675911799?thread_ts=1749580106.741049&cid=CAW1MAFLZ