### PR TITLE
fix(try-it): show section body even if auth is the only field present [TDX-6048]

### DIFF
--- a/src/components/spec-document/try-it/TryIt.vue
+++ b/src/components/spec-document/try-it/TryIt.vue
@@ -139,6 +139,7 @@ const sectionBodyEmpty = computed((): boolean =>
   (!props.data.request?.query || !props.data.request?.query.length) &&
   (!props.data.request?.path || !props.data.request?.path.length) &&
   (!props.data.request?.headers || !props.data.request?.headers.length) &&
+  (!props.data.security?.length) &&
   !currentRequestBody.value &&
   !response.value &&
   !responseError.value,


### PR DESCRIPTION
# Summary

The try-it auth section comes under try-it body section. The try-it body section is shown only if `sectionBodyEmpty` computed property is false.
The `sectionBodyEmpty` is false when the endpoint has none of the following:
- server variables
- query or path parameters
- custom headers
- request body
- try-it response body or error

<img width="934" alt="image" src="https://github.com/user-attachments/assets/8defe6e8-cdb3-4564-8b4b-bf5abc0cf0f2" />

This computed property was missing checking if `security` array for the endpoint had some data i.e. endpoint has auth setup. This PR adds checking for length of `security` array of the endpoint to the `sectionBodyEmpty` computed property.


## Verification

Can be verified using the `stoplight.yaml` spec available in sandbox

### Current 

<img width="1265" alt="image" src="https://github.com/user-attachments/assets/877fd3b4-5e01-4225-9126-4bfee7cd76e4" />

### Fixed

<img width="1259" alt="image" src="https://github.com/user-attachments/assets/27f2dc28-080d-400e-ad99-d027ab92e3d5" />



