### PR TITLE
fix: reading example from schema.example [TDX-6193]

### DIFF
--- a/src/utils/schema-example.spec.ts
+++ b/src/utils/schema-example.spec.ts
@@ -56,6 +56,25 @@ describe('extractSampleForParam', () => {
     expect(extractSampleForParam({ type: 'array' }, 'key')).toEqual('[]')
   })
 
+  it('should return example if defined in the schema', () => {
+    expect(extractSampleForParam({
+      'name': 'groupNumber',
+      'style': 'simple',
+      'examples': [
+        {
+          'id': '92b28d2be6cbd',
+          'value': 92,
+          'key': 'default',
+        },
+      ],
+      'schema': {
+        'type': 'integer',
+        'format': 'int64',
+        'example': 92,
+      },
+    }, 'groupNumber')).toEqual(92)
+  })
+
 })
 
 describe('crawl', () => {

--- a/src/utils/schema-example.ts
+++ b/src/utils/schema-example.ts
@@ -25,6 +25,13 @@ export const extractSampleForParam = (paramData: Record<string, any> | undefined
     }
   }
 
+  if (paramData.schema?.example) {
+    exampleValue = paramData.schema?.example
+    if (exampleValue !== undefined) {
+      return exampleValue
+    }
+  }
+
   if (paramData.examples) {
     exampleValue = paramData.examples[0]
     if (exampleValue !== undefined) {


### PR DESCRIPTION
# Summary
in `extractSampleForParam ` if `schema.example`  is present - read example value from there: 

```
{
      'name': 'groupNumber',
      'style': 'simple',
      'examples': [
        {
          'id': '92b28d2be6cbd',
          'value': 92,
          'key': 'default',
        },
      ],
      'schema': {
        'type': 'integer',
        'format': 'int64',
        'example': 92,                   // here is where we should read it from
      },
```

Before: 
![image](https://github.com/user-attachments/assets/0c26617c-635d-41ba-b6c2-df3b685701a7)


After: 
![image](https://github.com/user-attachments/assets/9059b1c6-955a-4d61-8ccd-63daf33fd5f6)


<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
