### PR TITLE
fix: pin @apidevtools/json-schema-ref-parser version to v14.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "vue": ">= 3.3.13 < 4"
   },
   "dependencies": {
-    "@apidevtools/json-schema-ref-parser": "^14.0.2",
+    "@apidevtools/json-schema-ref-parser": "14.0.3",
     "@asyncapi/openapi-schema-parser": "^3.0.24",
     "@asyncapi/parser": "^3.4.0",
     "@floating-ui/vue": "^1.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@apidevtools/json-schema-ref-parser':
-        specifier: ^14.0.2
-        version: 14.1.0
+        specifier: 14.0.3
+        version: 14.0.3
       '@asyncapi/openapi-schema-parser':
         specifier: ^3.0.24
         version: 3.0.24
@@ -229,8 +229,8 @@ packages:
   '@antfu/utils@0.7.10':
     resolution: {integrity: sha512-+562v9k4aI80m1+VuMHehNJWLOFjBnXn3tdOitzD0il5b7smkSBal4+a3oKiQTbrwMmN/TBUMDvbdoWDehgOww==}
 
-  '@apidevtools/json-schema-ref-parser@14.1.0':
-    resolution: {integrity: sha512-WFWymchOWHvk7wHLg0poBrpzbMyLBlc07XWKHsscAGYTT2r1KTslk5fA2ziFxmSc5q/JsREEPLCzkD2SI/nwfg==}
+  '@apidevtools/json-schema-ref-parser@14.0.3':
+    resolution: {integrity: sha512-XtI3vr6mq5ySDV7j+/ya7m9UDkRYN91NeSM5CBjGE8EZHXTuu5duHMm5emG+X8tmjRCYpEkWpHfxHpVR91owVg==}
     engines: {node: '>= 20'}
 
   '@asamuzakjp/css-color@2.8.3':
@@ -5573,7 +5573,7 @@ snapshots:
 
   '@antfu/utils@0.7.10': {}
 
-  '@apidevtools/json-schema-ref-parser@14.1.0':
+  '@apidevtools/json-schema-ref-parser@14.0.3':
     dependencies:
       '@types/json-schema': 7.0.15
       js-yaml: 4.1.0


### PR DESCRIPTION
# Summary

The latest version of `@apidevtools/json-schema-ref-parser`, `v14.1.0` has causing lots of specs to error out during bundling.

The console errors seem to be pointing to this line:

https://github.com/APIDevTools/json-schema-ref-parser/blob/dfbf4bb1c342c2cd49c41fc5761e28b0bb316539/lib/bundle.ts#L104

introduced in this commit:
https://github.com/APIDevTools/json-schema-ref-parser/commit/dfbf4bb1c342c2cd49c41fc5761e28b0bb316539


Currently, our package.json has the version set to `^14.0.2`, which leads to the installed version being `14.1.0` due to the `^`.

## Changes

- pin `@apidevtools/json-schema-ref-parser` to last working version, i.e. `14.0.3`

## Preview


https://github.com/user-attachments/assets/4ffec405-759b-452f-ba62-edf7ffe748ce

