### PR TITLE
fix: do not reset path and query values when headers change [TDX-6287]

### DIFF
--- a/src/components/spec-document/try-it/TryIt.vue
+++ b/src/components/spec-document/try-it/TryIt.vue
@@ -237,18 +237,12 @@ watch(() => props.requestBody, (body) => {
   currentRequestBody.value = body
 }, { immediate: true })
 
-watch(() => ({ id: props.data.id, authHeaderNameList: authHeaderNameList.value }), (newValue: any, oldValue) => {
+watch(() => (props.data.id), () => {
   currentRequestPath.value = getSamplePath(props.data)
   currentRequestQuery.value = getSampleQuery(props.data)
-  currentRequestHeaders.value = getSampleHeaders({ data: props.data, excludeHeaderList: newValue.authHeaderNameList })
-  if (newValue.id !== oldValue?.id || (
-    Array.isArray(newValue.authHeaderNameList) &&
-    Array.isArray(oldValue?.authHeaderNameList) &&
-    newValue.authHeaderNameList.length != oldValue.authHeaderNameList.length
-  )) {
-    response.value = undefined
-    responseError.value = undefined
-  }
+  currentRequestHeaders.value = getSampleHeaders({ data: props.data, excludeHeaderList: authHeaderNameList.value })
+  response.value = undefined
+  responseError.value = undefined
 }, { immediate: true })
 
 </script>


### PR DESCRIPTION
# Summary

prevent resetting already entered query and path values when headers or auth changes. 

before: 

https://github.com/user-attachments/assets/498ec3de-8b24-47f8-af72-31b8f589e4a7


after:

<img width="1042" height="1087" alt="image" src="https://github.com/user-attachments/assets/690fa944-0b5f-4d5e-83fc-84e9047e7ec2" />
