### PR TITLE
fix: do not include empty non-required query params into request [TDX-6287]

### DIFF
--- a/src/components/spec-document/samples/RequestSample.vue
+++ b/src/components/spec-document/samples/RequestSample.vue
@@ -296,7 +296,8 @@ watch(() => ({
       const reqData = ({
         method: newValue.method.toUpperCase(),
         // server.origin is set to null when protocol is invalid, we we have to use server.href here
-        url: serverUrl.href,
+        // but as queryString is passed separately we want to strip it out from url
+        url: serverUrl.href.replace(/\?.*/, ''),
         queryString: qObjArr,
         headers,
         postData: {

--- a/src/components/spec-document/try-it/TryItParams.vue
+++ b/src/components/spec-document/try-it/TryItParams.vue
@@ -232,9 +232,10 @@ watch(fieldValues, (newFieldValues) => {
 input[type=text] {
   @include input-default;
 }
+
 .required-label {
   color: var(--kui-icon-color-danger, $kui-icon-color-danger);
-  height: var(--kui-space-60, $kui-space-60);
+  height: 14px;
 }
 </style>
 

--- a/src/components/spec-document/try-it/TryItParams.vue
+++ b/src/components/spec-document/try-it/TryItParams.vue
@@ -24,6 +24,12 @@
           class="param-label"
           :for="`request-${paramType}-input-${params[pKey].name || pKey}-${data.id}`"
         >
+          <div
+            v-if="params[pKey].required"
+            class="required-label"
+          >
+            *
+          </div>
           {{ params[pKey].name || pKey }}
           <Tooltip
             v-if="params[pKey].description"
@@ -225,6 +231,10 @@ watch(fieldValues, (newFieldValues) => {
 
 input[type=text] {
   @include input-default;
+}
+.required-label {
+  color: var(--kui-icon-color-danger, $kui-icon-color-danger);
+  height: var(--kui-space-60, $kui-space-60);
 }
 </style>
 

--- a/src/utils/request-data.spec.ts
+++ b/src/utils/request-data.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { getRequestHeaders, getFormattedBody } from './request-data'
+import { getRequestHeaders, getFormattedBody, getSampleQuery } from './request-data'
 import type { IHttpOperation } from '@stoplight/types'
 
 describe('request-header', () => {
@@ -33,3 +33,57 @@ describe('getFormattedBody', () => {
   })
 })
 
+
+describe('getSampleQuery', () => {
+  it('should skip empty non-required values', () => {
+    expect(getSampleQuery({
+      id: '98ddd4beb64c5',
+      method: 'get',
+      path: '/reports',
+      request: {
+        query: [
+          // @ts-ignore just what's needed for test
+          {
+            'id': '95551eda46140',
+            'name': 'groupNpi',
+            'examples': [],
+            'description': 'Optional. Provider group NPI',
+            'required': false,
+            'schema': {
+              'type': 'string',
+              '$schema': 'http://json-schema.org/draft-07/schema#',
+              'description': 'Optional. Provider group NPI',
+            },
+            'explicitProperties': [
+              'name',
+              'in',
+              'required',
+              'description',
+              'schema',
+            ],
+          },
+          // @ts-ignore just what's needed for test
+          {
+            'id': 'a89c1e7c38da6',
+            'name': 'lastName',
+            'examples': [],
+            'description': 'Optional. Provider last name',
+            'required': true,
+            'schema': {
+              'type': 'string',
+              '$schema': 'http://json-schema.org/draft-07/schema#',
+              'description': 'Optional. Provider last name',
+            },
+            'explicitProperties': [
+              'name',
+              'in',
+              'required',
+              'description',
+              'schema',
+            ],
+          },
+        ],
+      },
+    })).toEqual('lastName=')
+  })
+})

--- a/src/utils/request-data.ts
+++ b/src/utils/request-data.ts
@@ -87,7 +87,10 @@ export const getSampleQuery = (data: IHttpOperation, fieldValues?: Record<string
   const urlParams = new URLSearchParams()
 
   Object.keys(myFieldValues).forEach(key => {
-    urlParams.append(key, myFieldValues[key])
+    const isRequired = data.request?.query?.find(r => r.name === key)?.required
+    if (isRequired || myFieldValues[key] !== '') {
+      urlParams.append(key, myFieldValues[key])
+    }
   })
 
   return urlParams.toString()


### PR DESCRIPTION
# Summary

Do not send empty not-required query string params in the TryIt request and do not show those in the request sample: 

in the example bellow we are always including `lastName` and `taxId` as those are required, and also including `firstName` and `show` as they have the value entered. Every other query param is skipped: 

<img width="1041" height="1225" alt="image" src="https://github.com/user-attachments/assets/02d8d8b3-c181-44b5-babf-f34f28479434" />
