### PR TITLE
fix: text only paste to body field [TDX-6222]

### DIFF
--- a/src/components/common/EditableCodeBlock.vue
+++ b/src/components/common/EditableCodeBlock.vue
@@ -12,7 +12,7 @@
       v-once
       ref="editableInput"
       class="editable-code"
-      contenteditable="true"
+      contenteditable="plaintext-only"
       spellcheck="false"
       @focusout="handleFocusOut"
       @input="handleInput"

--- a/src/components/spec-document/try-it/TryItAuth2.vue
+++ b/src/components/spec-document/try-it/TryItAuth2.vue
@@ -17,7 +17,7 @@
         v-model="authInputs[`${schemeKey}-clientId`]"
         :aria-describedby="`auth-input-oauth2-clientCredentials-clientId-${dataId}`"
         autocomplete="off"
-        placeholder="Enter your application credentials"
+        placeholder="Enter Client ID"
         type="text"
       >
     </div>
@@ -38,7 +38,7 @@
         v-model="authInputs[`${schemeKey}-clientSecret`]"
         :aria-describedby="`auth-input-oauth2-clientCredentials-secret-${dataId}`"
         autocomplete="off"
-        placeholder="Enter your application credentials"
+        placeholder="Enter Client Secret"
         type="password"
       >
     </div>
@@ -163,8 +163,9 @@ const auth2ClientCredentialsAuth = async (): Promise<Response | undefined> => {
     let resData = await resp.json()
     authInputs.value[`${props.schemeKey}-token`] = `${resData.token_type || 'Bearer'} ${resData.access_token}`
     await updateAuthDataImpl()
-    useTimeoutFn(() => {
+    useTimeoutFn(async () => {
       authInputs.value[`${props.schemeKey}-token`] = ''
+      await updateAuthDataImpl()
     }, (resData.expires_in || 60) * 1000)
   }
 


### PR DESCRIPTION
# Summary

- also cleanup header map when token expires in auth0 clientCreds flow [TDX-6235] missed checkin

before:  

https://github.com/user-attachments/assets/12e4d5ae-d60e-40fa-92da-db6cf5d367a5



after: 

https://github.com/user-attachments/assets/b7a180e4-b927-4b0c-9abf-2e2455b467d6



[TDX-6235]: https://konghq.atlassian.net/browse/TDX-6235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ