### PR TITLE
fix: add @apidevtools/json-schema-ref-parser so renovate is not picking it up

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,5 +14,8 @@
       ],
       "enabled": false
     }
+  ],
+  "ignoreDeps": [
+    "@apidevtools/json-schema-ref-parser"
   ]
 }


### PR DESCRIPTION
# Summary

Taw two times when renovate PR bumping version of this dependency was merged. we don't want it :) 