### PR TITLE
fix: do not show scopes in auth2 when scopes object is empty [TDX-6235]

### DIFF
--- a/src/components/spec-document/try-it/TryItAuth2.vue
+++ b/src/components/spec-document/try-it/TryItAuth2.vue
@@ -43,7 +43,7 @@
       >
     </div>
     <div
-      v-if="scheme.flows.clientCredentials?.scopes"
+      v-if="scheme.flows.clientCredentials?.scopes && Object.keys(scheme.flows.clientCredentials.scopes).length"
       class="param-wrapper"
     >
       <div class="button-wrapper">


### PR DESCRIPTION
# Summary

Do not show `scopes` header when there are no scopes
```
securitySchemes:
    OAuth2ClientCredentials:
      type: oauth2
      description: OAuth 2.0 client credentials flow
      flows:
        clientCredentials:
          tokenUrl: https://api.example.com/oauth/token
          scopes: {}
```

before: 

<img width="442" height="262" alt="image" src="https://github.com/user-attachments/assets/a5b8096b-c33e-44f6-91e6-77cf06e43db1" />


after: 
<img width="433" height="240" alt="image" src="https://github.com/user-attachments/assets/52f3a5f7-8847-49c1-9c08-ea692c0b5c69" />


