### PR TITLE
fix(schema-example): dont wrap example arrays with an array [TDX-6041]

### DIFF
--- a/src/utils/schema-example.spec.ts
+++ b/src/utils/schema-example.spec.ts
@@ -118,6 +118,29 @@ describe('crawl', () => {
     expect(crawl({ objData, filteringOptions: { excludeReadonly: false, excludeNotRequired: false } })).toEqual({ age: 0, name: 'name', refToName: 0 })
   })
 
+  it('should handle array example', () => {
+    const objData = {
+      'type': 'object',
+      'properties': {
+        'numbers': {
+          'type': 'array',
+          'items': {
+            'type': 'integer',
+            'example': [1, 2, 3],
+          },
+        },
+      },
+    }
+
+    const res = crawl({ objData, filteringOptions: { excludeReadonly: false, excludeNotRequired: false } })
+    expect(res).toEqual({
+      'numbers': [
+        1,
+        2,
+        3,
+      ],
+    })
+  })
 
   it('TDX-5892, value from enum', () => {
 

--- a/src/utils/schema-example.ts
+++ b/src/utils/schema-example.ts
@@ -197,20 +197,21 @@ export const crawl = ({ objData, parentKey = '', nestedLevel = 0, filteringOptio
         if (oDataType === 'array') {
           // if it's an array of objects, we'll generate the sample array item by crawling again
           // else, if there's no inherited fields, we'll generate the sample array item using extractSampleForParam
-          sampleObj[key] =
-            oData.itemType === 'object'
-              ? [doCrawl({
-                objData: oData || {},
-                parentKey: key,
-                nestedLevel: nestedLevel + 1,
-                filteringOptions,
-              })]
-              : [crawlInheritedProperties({
-                objData: oData,
-                parentKey: key,
-                nestedLevel: nestedLevel + 1,
-                filteringOptions,
-              }) ?? extractSampleForParam(oData, key)]
+          const exampleArrayItem = oData.itemType === 'object'
+            ? doCrawl({
+              objData: oData || {},
+              parentKey: key,
+              nestedLevel: nestedLevel + 1,
+              filteringOptions,
+            })
+            : crawlInheritedProperties({
+              objData: oData,
+              parentKey: key,
+              nestedLevel: nestedLevel + 1,
+              filteringOptions,
+            }) ?? extractSampleForParam(oData, key)
+          // if the exampleArrayItem is itself an array then we don't need to wrap it in an array
+          sampleObj[key] = Array.isArray(exampleArrayItem) ? exampleArrayItem : [exampleArrayItem]
         } else if (oDataType === 'object' || oData.allOf) {
           const res = doCrawl({ objData: oData || {}, parentKey: key, nestedLevel: nestedLevel + 1, filteringOptions })
           if (res !== null) {


### PR DESCRIPTION
# Summary

For schemas of array type, we were wrapping the generated example array-item with `[ ]`. However, if the schema already has an example, which itself is of type array, we don't need to do this and can instead directly return the example itself.

Jira ticket: https://konghq.atlassian.net/browse/TDX-6041

## Changes

- for array type schemas, only wrap generated example value with `[ ]` if it's not already an array
- add test case for this

## Preview

<img width="2461" height="1626" alt="image" src="https://github.com/user-attachments/assets/9dfe8eba-e769-4af0-8501-58f0c3809ff2" />

