### PR TITLE
fix: handle empty values [FTI-6857]

### DIFF
--- a/src/components/spec-document/try-it/TryItParams.vue
+++ b/src/components/spec-document/try-it/TryItParams.vue
@@ -219,7 +219,7 @@ watch(params, (newParams) => {
     const samples = extractSample(newParams)
     Object.keys(newParams).forEach(key => {
       // we need to keep it if it was previously changed, and only sent to example, when empty
-      fieldValues.value[key] = fieldValues.value[key] || samples[key]
+      fieldValues.value[key] = Object.keys(fieldValues.value).includes(key) ? fieldValues.value[key] : samples[key]
     })
   }
 }, { immediate: true })


### PR DESCRIPTION
# Summary

Respect empty values, so if value of the header was set to '' and then auth header changes - we preserve empty value instead of changing it to sample value.