### PR TITLE
fix: remove version prefix [TDX-6388]

### DIFF
--- a/src/components/spec-document/HttpService.vue
+++ b/src/components/spec-document/HttpService.vue
@@ -17,7 +17,7 @@
       </template>
       <div class="overview-page-versions">
         <LabelBadge
-          :label="`v${data.version}`"
+          :label="data.version"
           type="primary"
         />
         <LabelBadge


### PR DESCRIPTION
# Summary

Remove the version `v` prefix when displaying the version.

Since the version can be any freeform string, this could lead to `vv1.2` depending on how the user defines their version string in the spec.

<img width="189" height="103" alt="image" src="https://github.com/user-attachments/assets/d460b4ed-1f2d-40e2-a794-43844578c58e" />
