### PR TITLE
fix: add overflow-wrap anywhere for each h2

### DIFF
--- a/src/components/common/PageHeader.vue
+++ b/src/components/common/PageHeader.vue
@@ -72,6 +72,7 @@ defineProps({
       font-size: var(--kui-font-size-80, $kui-font-size-80);
       font-weight: var(--kui-font-weight-bold, $kui-font-weight-bold);
       line-height: var(--kui-line-height-70, $kui-line-height-70);
+      overflow-wrap: anywhere;
     }
 
     .page-header-actions {

--- a/src/components/spec-document/SpecDocument.vue
+++ b/src/components/spec-document/SpecDocument.vue
@@ -666,6 +666,10 @@ onBeforeMount(async () => {
   }
 }
 
+:deep(h2) {
+  overflow-wrap: anywhere;
+}
+
 .nodes-wrapper {
   .overview-page, .spec-renderer-document {
     margin-bottom: var(--kui-space-100, $kui-space-100);

--- a/src/components/spec-document/SpecDocument.vue
+++ b/src/components/spec-document/SpecDocument.vue
@@ -666,10 +666,6 @@ onBeforeMount(async () => {
   }
 }
 
-:deep(h2) {
-  overflow-wrap: anywhere;
-}
-
 .nodes-wrapper {
   .overview-page, .spec-renderer-document {
     margin-bottom: var(--kui-space-100, $kui-space-100);


### PR DESCRIPTION
# Summary

before: 

<img width="968" height="244" alt="image" src="https://github.com/user-attachments/assets/32c5da00-69bd-49d6-9245-dbdd70403773" />

after: 

<img width="1067" height="328" alt="image" src="https://github.com/user-attachments/assets/dfea545e-3e0f-48f5-8476-c46760a1d34f" />
