### PR TITLE
fix: avoid naming a variable declared with useTemplateRef the same as a template ref

### DIFF
--- a/src/components/spec-document/try-it/TryIt.vue
+++ b/src/components/spec-document/try-it/TryIt.vue
@@ -30,7 +30,7 @@
       class="tryit-body"
     >
       <TryItAuth
-        ref="authComponentRef"
+        ref="auth2ComponentTemplateRef"
         :data="data"
         @security-scheme-changed="securitySchemeChanged"
       />
@@ -110,7 +110,7 @@ const props = defineProps({
 
 })
 
-const authComponentRef = useTemplateRef<InstanceType<typeof TryItAuth>>('authComponentRef')
+const authComponentRef = useTemplateRef<InstanceType<typeof TryItAuth>>('authComponentTemplateRef')
 
 const excludeNotRequired = defineModel({
   type: Boolean,

--- a/src/components/spec-document/try-it/TryItAuth.vue
+++ b/src/components/spec-document/try-it/TryItAuth.vue
@@ -104,7 +104,7 @@
 
       <TryItAuth2
         v-else-if="scheme.type === 'oauth2' && scheme.flows.clientCredentials"
-        ref="auth2ComponentRef"
+        ref="auth2ComponentTemplateRef"
         :data-id="data.id"
         :scheme="scheme"
         :scheme-key="key"
@@ -161,7 +161,7 @@ const props = defineProps({
   },
 })
 
-const auth2ComponentRef = useTemplateRef<Array<InstanceType<typeof TryItAuth2>>>('auth2ComponentRef')
+const auth2ComponentRef = useTemplateRef<Array<InstanceType<typeof TryItAuth2>>>('auth2ComponentTemplateRef')
 
 const auth2ClientCredentialsAuth = async (): Promise<Response | undefined> => {
   if (!auth2ComponentRef.value?.[0].auth2ClientCredentialsAuth) {


### PR DESCRIPTION
# Summary

avoid vue warning in development mode: 

<img width="856" height="263" alt="image" src="https://github.com/user-attachments/assets/6d0acda4-0cad-4562-aff0-59ee1d926ff5" />


as suggested in: 

https://github.com/vuejs/core/issues/11795#issuecomment-2326858438

