### PR TITLE
fix: using NPM_TOKEN for cycjimmy/semantic-release-action [KHCP-17660]

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -147,3 +147,4 @@ jobs:
         env:
           # Since branch protections are on (pushing commits) you need to use a bot PAT
           GITHUB_TOKEN: ${{ secrets.SPEC_RENDERER_BOT_PAT }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN_PUBLIC_PUBLISH }}

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ if (typeof window !== 'undefined') {
  * It is used to ensure that path names are consistent and can be used in URIs.
  * It replaces spaces, slashes, and curly braces with dashes
  * and trims leading and trailing dashes.
- * @param name - The path to slugify.
- * @returns The slugified path
+ * @param name - The path name to slugify.
+ * @returns The slugified path name.
  */
 export { slugify as slugifyPath } from '@/stoplight/elements-core/utils/string'


### PR DESCRIPTION
# Summary

`cycjimmy/semantic-release-action` doesn't  support trusted OIDC , so we need to use token till we find the solution... 
