### PR TITLE
fix: cycjimmy/semantic-release-action with npmjs trusted [KHCP-17660]

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -12,6 +12,7 @@ on:
       - labeled
     branches:
       - main
+      - chore/KHCP-17660_npmjs-trusted-3
 
 permissions:
   id-token: write
@@ -147,4 +148,3 @@ jobs:
         env:
           # Since branch protections are on (pushing commits) you need to use a bot PAT
           GITHUB_TOKEN: ${{ secrets.SPEC_RENDERER_BOT_PAT }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN_PUBLIC_PUBLISH }}

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -148,3 +148,11 @@ jobs:
         env:
           # Since branch protections are on (pushing commits) you need to use a bot PAT
           GITHUB_TOKEN: ${{ secrets.SPEC_RENDERER_BOT_PAT }}
+
+        # as of now cycjimmy/semantic-release-action is not publishing  to npmjs as
+        # trusted publishing is not yet supported, so we want to do a publish as separate step
+      - name: Publish to npm
+        if: github.event_name == 'push'
+        run: |
+          npm --version
+          npm publish

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - chore/KHCP-17660_npmjs-trusted-3
   pull_request:
     types:
       - opened
@@ -12,7 +13,6 @@ on:
       - labeled
     branches:
       - main
-      - chore/KHCP-17660_npmjs-trusted-3
 
 permissions:
   id-token: write

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - chore/KHCP-17660_npmjs-trusted-3
+
   pull_request:
     types:
       - opened
@@ -154,5 +154,4 @@ jobs:
       - name: Publish to npm
         if: github.event_name == 'push'
         run: |
-          npm --version
           npm publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [1.98.19](https://github.com/Kong/spec-renderer/compare/v1.98.18...v1.98.19) (2025-08-19)
+
+
+### Bug Fixes
+
+* cycjimmy/semantic-release-action with npmjs trusted [KHCP-17660] ([4745fce](https://github.com/Kong/spec-renderer/commit/4745fce7e9de8dcc57339c86f6a9ec72047a582c))
+* debug on push ([1813faa](https://github.com/Kong/spec-renderer/commit/1813faa30e161f0a1f882816bfe75beb5bad400a))
+* debugging publshing from branch ([0f0ef49](https://github.com/Kong/spec-renderer/commit/0f0ef49c1d3a51dd5de40fbf5f51e6a1b85bd5db))
+* using NPM_TOKEN for cycjimmy/semantic-release-action [KHCP-17660] ([#690](https://github.com/Kong/spec-renderer/issues/690)) ([935a94e](https://github.com/Kong/spec-renderer/commit/935a94e8f173713fbb60fdc65d8ee6c1d2bb4260))
+
 ## [1.98.18](https://github.com/Kong/spec-renderer/compare/v1.98.17...v1.98.18) (2025-08-19)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kong/spec-renderer",
-  "version": "1.98.18",
+  "version": "1.98.19",
   "description": "Kong's open-source spec renderer",
   "license": "Apache-2.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -172,7 +172,12 @@
           "changelogFile": "CHANGELOG.md"
         }
       ],
-      "@semantic-release/npm",
+      [
+        "@semantic-release/npm",
+        {
+          "npmPublish": false
+        }
+      ],
       [
         "@semantic-release/git",
         {

--- a/package.json
+++ b/package.json
@@ -152,7 +152,6 @@
     "branches": [
       "+([0-9])?(.{+([0-9]),x}).x",
       "main",
-      "chore/KHCP-17660_npmjs-trusted-3",
       "next",
       "next-major",
       {

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "branches": [
       "+([0-9])?(.{+([0-9]),x}).x",
       "main",
+      "chore/KHCP-17660_npmjs-trusted-3",
       "next",
       "next-major",
       {


### PR DESCRIPTION
# Summary

As of now `cycjimmy/semantic-release-action` is not supporting npmjs trusted publishing, so instead we will make it do everything but publishing, and perform publishing as separate `npm publish` step.
