### PR TITLE
fix(try-it): fix try it auth ref identifier

### DIFF
--- a/src/components/spec-document/try-it/TryIt.vue
+++ b/src/components/spec-document/try-it/TryIt.vue
@@ -110,7 +110,7 @@ const props = defineProps({
 
 })
 
-const authComponentRef = useTemplateRef<InstanceType<typeof TryItAuth>>('authComponentTemplateRef')
+const authComponentRef = useTemplateRef<InstanceType<typeof TryItAuth>>('auth2ComponentTemplateRef')
 
 const excludeNotRequired = defineModel({
   type: Boolean,


### PR DESCRIPTION
Incorrect identifier leads to no access token being retrieved