### PR TITLE
feat: anchor link for operation properties [TDX-7550]

### DIFF
--- a/sandbox/pages/SpecRendererPlayground.vue
+++ b/sandbox/pages/SpecRendererPlayground.vue
@@ -116,7 +116,7 @@ import { useRoute as useVueRoute } from 'vue-router'
 
 const route = useVueRoute()
 
-const navigationType = ref<NavigationTypes>(route.hash ? 'hash' : 'path')
+const navigationType = ref<NavigationTypes>(route.hash?.startsWith('#/') ? 'hash' : 'path')
 
 const specText = ref<string>('')
 const specUrl = ref<string>('')

--- a/sandbox/pages/SpecRendererPlayground.vue
+++ b/sandbox/pages/SpecRendererPlayground.vue
@@ -90,6 +90,7 @@
       base-path="/spec-renderer"
       :control-address-bar="true"
       :current-path="currentPath"
+      enable-property-links
       :hide-deprecated="hideDeprecated"
       :hide-insomnia-try-it="hideTryItInsomnia"
       :hide-navigation-buttons="hideNavigationButtons"

--- a/src/components/SpecRenderer.vue
+++ b/src/components/SpecRenderer.vue
@@ -60,6 +60,7 @@
           :current-path="currentPathDOC"
           :document="parsedDocument"
           :document-scrolling-container="documentScrollingContainer"
+          :enable-property-links="enablePropertyLinks"
           :hide-download-button="hideDownloadButton"
           :hide-insomnia-try-it="hideInsomniaTryIt"
           :hide-navigation-buttons="hideNavigationButtons"
@@ -112,6 +113,7 @@ const {
   hideDownloadButton = false,
   showPoweredBy = false,
   maxExpandedDepth = DEFAULT_EXPANDED_PROPERTIES_DEPTH,
+  enablePropertyLinks = false,
 } = defineProps<SpecRendererProps>()
 
 // TODO: introduce and handle isParsed. show parsing state while parsing

--- a/src/components/spec-document/HttpOperation.spec.ts
+++ b/src/components/spec-document/HttpOperation.spec.ts
@@ -2,6 +2,7 @@ import { ref } from 'vue'
 import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
 import HttpOperation from './HttpOperation.vue'
+import HttpOperationBody from './endpoint/HttpOperationBody.vue'
 import type { IHttpOperation, IServer } from '@stoplight/types'
 import composables from '@/composables'
 
@@ -152,6 +153,62 @@ describe('<HttpOperation />', () => {
 
       // server endpoint is not rendered
       expect(wrapper.findTestId(`server-endpoint-${data.id}`).exists()).toBe(false)
+    })
+  })
+
+  describe('Property Links', () => {
+    const operationData: IHttpOperation = {
+      id: '123',
+      method: 'get',
+      path: '/pets',
+      responses: [{
+        id: 'res-200',
+        code: '200',
+        contents: [{
+          id: 'content-1',
+          mediaType: 'application/json',
+          schema: { type: 'object', properties: { name: { type: 'string' } } },
+        }],
+      }],
+      request: {
+        body: {
+          id: 'body-1',
+          contents: [{
+            id: 'content-2',
+            mediaType: 'application/json',
+            schema: { type: 'object', properties: { email: { type: 'string' } } },
+          }],
+        },
+      },
+    }
+
+    it('passes basePathId to HttpOperationBody when enable-property-links is true', () => {
+      const wrapper = mount(HttpOperation, {
+        props: { data: operationData },
+        global: {
+          provide: {
+            'enable-property-links': ref(true),
+          },
+        },
+      })
+
+      const bodies = wrapper.findAllComponents(HttpOperationBody)
+      const requestBody = bodies.find(b => b.classes().includes('http-operation-request-body'))
+      const responseBody = bodies.find(b => b.classes().includes('http-operation-response'))
+
+      expect(requestBody?.props('basePathId')).toBe('get-pets-request-body')
+      expect(responseBody?.props('basePathId')).toBe('get-pets-response-200')
+    })
+
+    it('does not pass basePathId when enable-property-links is not provided', () => {
+      const wrapper = mount(HttpOperation, {
+        props: { data: operationData },
+      })
+
+      const bodies = wrapper.findAllComponents(HttpOperationBody)
+      bodies.forEach(body => {
+        expect(body.props('basePathId')).toBe('')
+      })
     })
   })
 })

--- a/src/components/spec-document/HttpOperation.vue
+++ b/src/components/spec-document/HttpOperation.vue
@@ -184,7 +184,7 @@ import ServerEndpoint from './endpoint/ServerEndpoint.vue'
 import ResponseTypeSelect from './endpoint/ResponseTypeSelect.vue'
 import PageHeader from '../common/PageHeader.vue'
 import SelectDropdown from '@/components/common/SelectDropdown.vue'
-import { getSamplePath, getSampleQuery, getSampleBody, getSampleHeaders, kebabCase } from '@/utils'
+import { getSamplePath, getSampleQuery, getSampleBody, getSampleHeaders, slugify } from '@/utils'
 import composables from '@/composables'
 import type { SecuritySchemeGroup, RequestBody } from '@/types'
 
@@ -231,20 +231,24 @@ const operationData = computed(() => ({
 
 const isWebhookOperation = computed(() => 'name' in props.data)
 
-const operationBasePathId = computed(() =>
-  enablePropertyLinks.value && operationData.value.id ? kebabCase(operationData.value.id) : '',
-)
+const operationBasePathId = computed(() => {
+  if (!enablePropertyLinks.value) return ''
+  const method = operationData.value.method
+  const pathOrName = operationData.value.path || operationData.value.name
+  if (!method || !pathOrName) return ''
+  return slugify(`${method} ${pathOrName.replace(/[/{}]+/g, ' ')}`)
+})
 const requestBodyBasePathId = computed(() =>
-  operationBasePathId.value ? kebabCase(`${operationBasePathId.value}-request-body`) : '',
+  operationBasePathId.value ? slugify(`${operationBasePathId.value}-request-body`) : '',
 )
 const responseBasePathId = computed(() =>
-  enablePropertyLinks.value && operationData.value.id && activeResponseCode.value
-    ? kebabCase(`${operationData.value.id}-response-${activeResponseCode.value}`)
+  operationBasePathId.value && activeResponseCode.value
+    ? slugify(`${operationBasePathId.value}-response-${activeResponseCode.value}`)
     : '',
 )
 const callbackResponseBasePathId = computed(() =>
-  enablePropertyLinks.value && operationData.value.id && activeCallbackKey.value && activeCallbackResponseCode.value
-    ? kebabCase(`${operationData.value.id}-callback-${activeCallbackKey.value}-response-${activeCallbackResponseCode.value}`)
+  operationBasePathId.value && activeCallbackKey.value && activeCallbackResponseCode.value
+    ? slugify(`${operationBasePathId.value}-callback-${activeCallbackKey.value}-response-${activeCallbackResponseCode.value}`)
     : '',
 )
 

--- a/src/components/spec-document/HttpOperation.vue
+++ b/src/components/spec-document/HttpOperation.vue
@@ -32,9 +32,11 @@
         <HttpRequest
           v-if="operationData.request"
           v-bind="operationData.request"
+          :base-path-id="operationBasePathId"
         >
           <HttpOperationBody
             v-if="activeRequestBodyContentList.length"
+            :base-path-id="requestBodyBasePathId"
             class="http-operation-request-body"
             :content-list="activeRequestBodyContentList"
             :description="operationData.request.body?.description"
@@ -49,6 +51,7 @@
         </HttpRequest>
 
         <HttpOperationBody
+          :base-path-id="responseBasePathId"
           class="http-operation-response"
           :content-list="activeResponseContentList"
           :description="activeResponseDescription"
@@ -75,6 +78,7 @@
 
           <template #callback-response>
             <HttpOperationBody
+              :base-path-id="callbackResponseBasePathId"
               :content-list="activeCallbackResponseContentList"
               :description="activeCallbackResponseDescription"
               title="Callback Response"
@@ -180,7 +184,7 @@ import ServerEndpoint from './endpoint/ServerEndpoint.vue'
 import ResponseTypeSelect from './endpoint/ResponseTypeSelect.vue'
 import PageHeader from '../common/PageHeader.vue'
 import SelectDropdown from '@/components/common/SelectDropdown.vue'
-import { getSamplePath, getSampleQuery, getSampleBody, getSampleHeaders } from '@/utils'
+import { getSamplePath, getSampleQuery, getSampleBody, getSampleHeaders, kebabCase } from '@/utils'
 import composables from '@/composables'
 import type { SecuritySchemeGroup, RequestBody } from '@/types'
 
@@ -214,6 +218,7 @@ const securitySchemeGroupList = computed<SecuritySchemeGroup[]>(() => {
 provide<ComputedRef<SecuritySchemeGroup[]>>('security-scheme-group-list', securitySchemeGroupList)
 
 const hideTryIt = inject<Ref<boolean>>('hide-tryit', ref(false))
+const enablePropertyLinks = inject<Ref<boolean>>('enable-property-links', ref(false))
 
 const excludeNotRequiredInTryIt = ref<boolean>(true)
 const excludeNotRequiredInSample = ref<boolean>(true)
@@ -225,6 +230,23 @@ const operationData = computed(() => ({
 }))
 
 const isWebhookOperation = computed(() => 'name' in props.data)
+
+const operationBasePathId = computed(() =>
+  enablePropertyLinks.value && operationData.value.id ? kebabCase(operationData.value.id) : '',
+)
+const requestBodyBasePathId = computed(() =>
+  operationBasePathId.value ? kebabCase(`${operationBasePathId.value}-request-body`) : '',
+)
+const responseBasePathId = computed(() =>
+  enablePropertyLinks.value && operationData.value.id && activeResponseCode.value
+    ? kebabCase(`${operationData.value.id}-response-${activeResponseCode.value}`)
+    : '',
+)
+const callbackResponseBasePathId = computed(() =>
+  enablePropertyLinks.value && operationData.value.id && activeCallbackKey.value && activeCallbackResponseCode.value
+    ? kebabCase(`${operationData.value.id}-callback-${activeCallbackKey.value}-response-${activeCallbackResponseCode.value}`)
+    : '',
+)
 
 const excludeNotRequired = computed((): boolean => {
   return hideTryIt.value ? excludeNotRequiredInSample.value : excludeNotRequiredInTryIt.value

--- a/src/components/spec-document/SpecDocument.vue
+++ b/src/components/spec-document/SpecDocument.vue
@@ -193,6 +193,14 @@ const props = defineProps({
     validator: NUMBER_VALIDATOR,
     default: DEFAULT_EXPANDED_PROPERTIES_DEPTH,
   },
+  /**
+   * Enable links to individual properties of operation request/response schemas.
+   */
+  enablePropertyLinks: {
+    type: [Boolean, String],
+    validator: BOOL_VALIDATOR,
+    default: false,
+  },
 })
 
 const { highlighter, createHighlighter } = composables.useShiki()
@@ -214,6 +222,7 @@ provide<ComputedRef<boolean>>('hide-tryit', computed((): boolean => IS_TRUE(prop
 provide<ComputedRef<boolean>>('hide-insomnia-tryit', computed((): boolean => IS_TRUE(props.hideInsomniaTryIt)))
 provide<ComputedRef<boolean>>('markdown-styles', computed((): boolean => IS_TRUE(props.markdownStyles)))
 provide<ComputedRef<number>>('max-expanded-depth', computed((): number => convertToNumber(props.maxExpandedDepth) || DEFAULT_EXPANDED_PROPERTIES_DEPTH))
+provide<ComputedRef<boolean>>('enable-property-links', computed((): boolean => IS_TRUE(props.enablePropertyLinks)))
 
 const emit = defineEmits<{
   (e: 'path-not-found', requestedPath: string): void

--- a/src/components/spec-document/endpoint/BodyContentList.vue
+++ b/src/components/spec-document/endpoint/BodyContentList.vue
@@ -24,10 +24,14 @@
             {{ content.schema.title }}
           </h4>
         </template>
-        <ContentListItemSchema :schema="parseSchema(content.schema)" />
+        <ContentListItemSchema
+          :base-path-id="basePathId"
+          :schema="parseSchema(content.schema)"
+        />
       </CollapsibleSection>
       <ContentListItemSchema
         v-else-if="content.schema"
+        :base-path-id="basePathId"
         :schema="parseSchema(content.schema)"
       />
     </template>
@@ -44,6 +48,10 @@ import type { SchemaObject } from '@/types'
 import { removeFieldsFromSchemaObject, removeReadonlyFields, resolveSchemaObjectFields } from '@/utils'
 
 const props = defineProps({
+  basePathId: {
+    type: String,
+    default: '',
+  },
   description: {
     type: String,
     default: '',

--- a/src/components/spec-document/endpoint/ContentListItemSchema.vue
+++ b/src/components/spec-document/endpoint/ContentListItemSchema.vue
@@ -6,6 +6,7 @@
       :required-fields="schema.required"
     />
     <ModelNode
+      :base-path-id="basePathId"
       :schema="schema"
       :title="schema.title"
     />
@@ -19,6 +20,10 @@ import ModelNode from '@/components/spec-document/schema-model/ModelNode.vue'
 import PropertyFieldList from '@/components/spec-document/schema-model/PropertyFieldList.vue'
 
 const { schema } = defineProps({
+  basePathId: {
+    type: String,
+    default: '',
+  },
   schema: {
     type: Object as PropType<SchemaObject>,
     required: true,

--- a/src/components/spec-document/endpoint/HttpOperationBody.vue
+++ b/src/components/spec-document/endpoint/HttpOperationBody.vue
@@ -12,6 +12,7 @@
       </template>
 
       <BodyContentList
+        :base-path-id="basePathId"
         :contents="contentList"
         :description="description"
         :hide-readonly="hideReadonly"
@@ -27,6 +28,10 @@ import CollapsibleSection from './CollapsibleSection.vue'
 import BodyContentList from './BodyContentList.vue'
 
 defineProps({
+  basePathId: {
+    type: String,
+    default: '',
+  },
   description: {
     type: String,
     default: '',

--- a/src/components/spec-document/endpoint/HttpRequest.vue
+++ b/src/components/spec-document/endpoint/HttpRequest.vue
@@ -20,6 +20,7 @@ import { computed, toRefs } from 'vue'
 import type { PropType } from 'vue'
 import type { IHttpPathParam, IHttpQueryParam, IHttpHeaderParam } from '@stoplight/types'
 import RequestParamList from './RequestParamList.vue'
+import { kebabCase } from '@/utils'
 
 const props = defineProps({
   query: {
@@ -33,6 +34,10 @@ const props = defineProps({
   headers: {
     type: Array as PropType<IHttpHeaderParam[]>,
     default: () => [],
+  },
+  basePathId: {
+    type: String,
+    default: '',
   },
   titlePrefix: {
     type: String,
@@ -53,6 +58,7 @@ const componentList = computed(() => {
         paramList: query.value,
         title: `${titlePrefixWithSpace}Query Parameters`,
         'data-testid': 'endpoint-query-param-list',
+        ...(props.basePathId ? { basePathId: kebabCase(`${props.basePathId}-query`) } : null),
       },
       key: 'query',
     })
@@ -64,6 +70,7 @@ const componentList = computed(() => {
         paramList: path.value,
         title: `${titlePrefixWithSpace}Path Parameters`,
         'data-testid': 'endpoint-path-param-list',
+        ...(props.basePathId ? { basePathId: kebabCase(`${props.basePathId}-path`) } : null),
       },
       key: 'path',
     })
@@ -75,6 +82,7 @@ const componentList = computed(() => {
         paramList: headers.value,
         title: `${titlePrefixWithSpace}Headers`,
         'data-testid': 'endpoint-header-param-list',
+        ...(props.basePathId ? { basePathId: kebabCase(`${props.basePathId}-header`) } : null),
       },
       key: 'headers',
     })

--- a/src/components/spec-document/endpoint/RequestParamList.vue
+++ b/src/components/spec-document/endpoint/RequestParamList.vue
@@ -10,6 +10,7 @@
       >
         <ModelProperty
           v-if="param.schema"
+          :base-path-id="basePathId"
           :property="{ ...param.schema, ...populateParamProperty(param, param.schema) }"
           :property-name="param.name"
           :required-fields="paramItemRequiredFields(param)"
@@ -27,6 +28,10 @@ import CollapsibleSection from './CollapsibleSection.vue'
 import type { SchemaObject } from '@/types'
 
 defineProps({
+  basePathId: {
+    type: String,
+    default: '',
+  },
   paramList: {
     type: Array as PropType<IHttpParam[]>,
     required: true,

--- a/src/components/spec-document/schema-model/ModelProperty.vue
+++ b/src/components/spec-document/schema-model/ModelProperty.vue
@@ -137,8 +137,9 @@ onMounted(() => {
   if (hash.length) {
     // if the hash is the same as the current component's propertyId it means we want to show the current component
     // so we scroll to the current component
+    // delay to ensure parent container scroll (e.g. SpecDocument) settles first
     if (hash === propertyIDHash) {
-      currentElement.value?.scrollIntoView({ behavior: 'smooth' })
+      setTimeout(() => currentElement.value?.scrollIntoView({ behavior: 'smooth' }), 100)
     } else if (hash.startsWith(propertyIDHash)) {
       nestedPropertiesExpanded.value = true
       // only mess with the details element during mounted

--- a/src/types/spec-renderer.ts
+++ b/src/types/spec-renderer.ts
@@ -56,6 +56,8 @@ export interface SpecRendererProps {
   showPoweredBy?: boolean | 'true' | 'false'
   /** The max depth until which nested properties should remain expanded by default. */
   maxExpandedDepth?: number | string
+  /** Enable links to individual properties of operation request/response schemas. */
+  enablePropertyLinks?: boolean | 'true' | 'false'
 }
 
 /**


### PR DESCRIPTION
# Summary

This PR aims to add anchor links for operation properties so that users can easily share links to them.

**Gaps in current implementation** - If the user selects a different API response status than the default in the dropdown then the link does not work properly on re-load or sharing.

**Jira** - https://konghq.atlassian.net/browse/TDX-7550

**Video**

https://github.com/user-attachments/assets/7ebf7e67-5f19-4776-9b34-bce6feae9deb




<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
