### PR TITLE
fix: render array request body in spec [FTI-7314]

### DIFF
--- a/src/utils/request-data.spec.ts
+++ b/src/utils/request-data.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { getRequestHeaders, getFormattedBody, getSampleQuery } from './request-data'
+import { getRequestHeaders, getFormattedBody, getSampleQuery, getSampleBody } from './request-data'
 import type { IHttpOperation } from '@stoplight/types'
 
 describe('request-header', () => {
@@ -32,6 +32,39 @@ describe('getFormattedBody', () => {
   })
 })
 
+
+describe('getSampleBody', () => {
+  it('should wrap array schema body in an array', () => {
+    const contents = [{
+      id: 'test',
+      mediaType: 'application/json',
+      schema: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            firstName: { type: 'string', example: 'John' },
+          },
+        },
+      },
+    }]
+    expect(getSampleBody(contents as any)).toEqual(JSON.stringify([{ firstName: 'John' }], null, 2))
+  })
+
+  it('should not wrap object schema body in an array', () => {
+    const contents = [{
+      id: 'test',
+      mediaType: 'application/json',
+      schema: {
+        type: 'object',
+        properties: {
+          firstName: { type: 'string', example: 'John' },
+        },
+      },
+    }]
+    expect(getSampleBody(contents as any)).toEqual(JSON.stringify({ firstName: 'John' }, null, 2))
+  })
+})
 
 describe('getSampleQuery', () => {
   it('should skip empty non-required values', () => {

--- a/src/utils/request-data.ts
+++ b/src/utils/request-data.ts
@@ -1,6 +1,6 @@
 import type { IHttpOperation, IMediaTypeContent } from '@stoplight/types'
 import { crawl, extractSampleForParam } from './schema-example'
-import { resolveSchemaObjectFields } from './schema-model'
+import { resolveSchemaObjectFields, resolveSchemaType } from './schema-model'
 import { CODE_INDENT_SPACES } from '@/constants'
 import { safeJSONParse } from './strings'
 import formurlencoded from 'form-urlencoded'
@@ -143,14 +143,12 @@ export const getSampleBody = (contents: IMediaTypeContent[], filteringOptions: R
     }
   }
 
-  return JSON.stringify(
-    crawl({
-      objData: resolveSchemaObjectFields(contents[0].schema) as Record<string, any>,
-      filteringOptions,
-    }),
-    null,
-    CODE_INDENT_SPACES,
-  )
+  const isArraySchema = resolveSchemaType(contents[0].schema?.type) === 'array'
+  const sample = crawl({
+    objData: resolveSchemaObjectFields(contents[0].schema) as Record<string, any>,
+    filteringOptions,
+  })
+  return JSON.stringify(isArraySchema && !Array.isArray(sample) ? [sample] : sample, null, CODE_INDENT_SPACES)
 }
 
 /**


### PR DESCRIPTION
# Summary

This PR aims to fix rendering of array request body where schema is `type: array` of objects. `getSampleBody` generates a plain object instead of an array. `crawl` receives the flattened schema with properties, iterates them, and returns an object. Nothing wraps this in `[]`.

**Jira** - https://konghq.atlassian.net/browse/FTI-7314

**Consuming app PR** - https://github.com/kong-konnect/portal/pull/2192

**Preview link** - You can use this link - https://pr-2192-portal-ui-dev.konghq.workers.dev/apis/sample-api-with-array-request-body-1/versions/115ef176-8469-4f3d-8c71-1362a0abe256 with this portal to test - https://b0af88bbbe67.us.kongportals.tech. Just add any custom API base url to see the request body.

**Demo**

Uploaded the sample spec provided in the Jira and tested in spec-renderer sandbox.

https://github.com/user-attachments/assets/6400e259-d6da-4da0-81ed-3ea93eaabc08

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
