### PR TITLE
fix: resolve allOf fields not rendering for schemas with circular refs [FTI-7346]

### DIFF
--- a/src/utils/schema-model.spec.ts
+++ b/src/utils/schema-model.spec.ts
@@ -156,6 +156,47 @@ describe('resolveSchemaObjectFields', () => {
       expect(resolveSchemaObjectFields(invalidSchemaObject)).toStrictEqual(invalidSchemaObject)
     }
   })
+  it('returns Schema Object with merged allOf fields when circular references exist', () => {
+    const parentSchema: SchemaObject = { type: 'object', allOf: [] }
+    const firstAllOfObject: SchemaObject = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+      },
+      required: ['name'],
+      oneOf: [parentSchema], // circular reference back to parentSchema
+    }
+    const secondAllOfObject: SchemaObject = {
+      type: 'object',
+      properties: {
+        age: { type: 'number' },
+      },
+      required: ['age'],
+    }
+    parentSchema.allOf = [firstAllOfObject, secondAllOfObject]
+
+    const result = resolveSchemaObjectFields(parentSchema)
+    expect(result.properties).toHaveProperty('name')
+    expect(result.properties).toHaveProperty('age')
+    expect(result.required).toContain('name')
+    expect(result.required).toContain('age')
+  })
+
+  it('preserves title in Schema Object with merged allOf fields when circular references exist', () => {
+    const parentSchema: SchemaObject = { title: 'ParentTitle', type: 'object', allOf: [] }
+    const firstAllOfObject: SchemaObject = {
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      oneOf: [parentSchema], // circular reference back to parentSchema
+    }
+    parentSchema.allOf = [firstAllOfObject, { type: 'object', properties: { age: { type: 'number' } } }]
+
+    const result = resolveSchemaObjectFields(parentSchema)
+    expect(result.title).toBe('ParentTitle')
+    expect(result.properties).toHaveProperty('name')
+    expect(result.properties).toHaveProperty('age')
+  })
+
   it('returns Schema Object with merged allOf fields', () => {
     const firstAllOfObject: SchemaObject = {
       type: 'object',

--- a/src/utils/schema-model.ts
+++ b/src/utils/schema-model.ts
@@ -49,14 +49,24 @@ const resolveAllOf = (schema: SchemaObject): SchemaObject => {
     try {
       JSON.stringify(schema)
     } catch {
-      // yes, we do have circular references, merge will fail, let's do it simpler way
-
-      let resolvedAllOf: SchemaObject = {}
-      for (const allEl of schema.allOf) {
-        resolvedAllOf = { ...resolveAllOf, ...removeCircularRefs(allEl as Record<string, any>) as Record<string, any> }
-      }
+      // circular references detected, for each allOf item, only call removeCircularRefs if the
+      // item itself is circular, otherwise use it as-is to preserve shared schema references
+      // (e.g. two properties pointing to the same $ref object). also strip oneOf/anyOf to
+      // avoid showing inherited variant selectors
+      const cleanedAllOf = filterSchemaObjectArray(schema.allOf).map((item) => {
+        let result: SchemaObject
+        try {
+          JSON.stringify(item)
+          result = { ...item }
+        } catch {
+          result = removeCircularRefs(item)
+        }
+        delete result.oneOf
+        delete result.anyOf
+        return result
+      })
       return {
-        ...resolvedAllOf,
+        ...(merge({ ...schema, allOf: cleanedAllOf }, { mergeCombinarySibling: true }) as SchemaObject),
         ...(schema.title ? { title: schema.title } : {}),
       }
     }


### PR DESCRIPTION
# Summary

This PR aims to resolve rendering of allOf fields when there are circular refs.

**Jira** - https://konghq.atlassian.net/browse/FTI-7346

**Portal PR** - https://github.com/kong-konnect/portal/pull/2266

Fixed issues:-
1. `...resolveAllOf` was being spread instead of `...resolvedAllOf`, discarding all previously accumulated properties each iteration.
2. Shallow merge overwrote instead of deep-merging.
3. `removeCircularRefs` uses a visited-object Set, so when two properties in the same `allOf` item point to the same dereferenced object (eg. `localizable_string` in both `host_info.description` and `house_rules` in this issue), the second one gets stripped. Fixed by skipping `removeCircularRefs` on `allOf` items that aren't actually circular. Non-circular items are used as-is, preserving all shared references.

**Before**

`hotel_content` schema rendered without `lodging_content` fields.

<img width="604" height="951" alt="Screenshot 2026-04-13 at 7 26 42 PM" src="https://github.com/user-attachments/assets/94e16853-7091-430d-9337-9cb389a00b80" />

**After**

The video below covers differences in rendered schemas from prod. and local.

https://github.com/user-attachments/assets/7f19260a-254a-418f-9bfc-c92d27cc5d8d




<!--
  Be sure your Pull Request includes:



  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
