### PR TITLE
fix(schema-example): handle null example values [TDX-7862]

### DIFF
--- a/src/utils/request-data.spec.ts
+++ b/src/utils/request-data.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { getRequestHeaders, getFormattedBody, getSampleQuery, getSampleBody } from './request-data'
+import { extractSample, getRequestHeaders, getFormattedBody, getSampleQuery, getSampleBody } from './request-data'
 import type { IHttpOperation } from '@stoplight/types'
 
 describe('request-header', () => {
@@ -66,8 +66,23 @@ describe('getSampleBody', () => {
   })
 })
 
+describe('extractSample', () => {
+  it('should use param name as key when input is an array (Stoplight format)', () => {
+    // data.request.query is an IHttpQueryParam array, not a Record.
+    // extractSample must use param.name as both the output key and the key
+    // passed to extractSampleForParam, not the array index.
+    const result = extractSample([
+      // @ts-ignore testing array input
+      { name: 'query', schema: { type: 'string' }, examples: [{ id: '1', key: 'default', value: null }] },
+      // @ts-ignore
+      { name: 'page', schema: { type: 'integer' }, examples: [] },
+    ])
+    expect(result).toEqual({ query: 'query', page: 0 })
+  })
+})
+
 describe('getSampleQuery', () => {
-  it('should skip empty non-required values', () => {
+  it('should include required params and non-required params with non-empty example values', () => {
     expect(getSampleQuery({
       id: '98ddd4beb64c5',
       method: 'get',
@@ -86,13 +101,6 @@ describe('getSampleQuery', () => {
               '$schema': 'http://json-schema.org/draft-07/schema#',
               'description': 'Optional. Provider group NPI',
             },
-            'explicitProperties': [
-              'name',
-              'in',
-              'required',
-              'description',
-              'schema',
-            ],
           },
           // @ts-ignore just what's needed for test
           {
@@ -106,16 +114,63 @@ describe('getSampleQuery', () => {
               '$schema': 'http://json-schema.org/draft-07/schema#',
               'description': 'Optional. Provider last name',
             },
-            'explicitProperties': [
-              'name',
-              'in',
-              'required',
-              'description',
-              'schema',
-            ],
           },
         ],
       },
-    })).toEqual('lastName=')
+    })).toEqual('groupNpi=groupNpi&lastName=lastName')
+  })
+
+  it('should skip non-required params whose example value is an explicit empty string', () => {
+    expect(getSampleQuery({
+      id: 'test-id',
+      method: 'get',
+      path: '/search',
+      request: {
+        query: [
+          // @ts-ignore
+          {
+            name: 'optional',
+            required: false,
+            examples: [{ id: '1', key: 'default', value: '' }],
+            schema: { type: 'string' },
+          },
+          // @ts-ignore
+          {
+            name: 'required',
+            required: true,
+            examples: [{ id: '2', key: 'default', value: '' }],
+            schema: { type: 'string' },
+          },
+        ],
+      },
+    })).toEqual('required=')
+  })
+
+  it('should use param names (not array indices) for Stoplight params with null examples', () => {
+    expect(getSampleQuery({
+      id: '913107ebad7de',
+      method: 'get',
+      path: '/search',
+      request: {
+        query: [
+          // @ts-ignore
+          {
+            id: '3aea5c6215895',
+            name: 'query',
+            required: false,
+            examples: [{ id: '94444b275ec09', value: null, key: 'default' }],
+            schema: { type: 'string', examples: [null] },
+          },
+          // @ts-ignore
+          {
+            id: 'dc4d5d8651257',
+            name: 'filter',
+            required: false,
+            examples: [{ id: '93d27aa688c6b', key: 'default', value: null }],
+            schema: { type: 'string' },
+          },
+        ],
+      },
+    })).toEqual('query=query&filter=filter')
   })
 })

--- a/src/utils/request-data.ts
+++ b/src/utils/request-data.ts
@@ -45,7 +45,8 @@ export const extractSample = (paramData: Record<string, any> | undefined): Recor
   }
 
   Object.keys(paramData).forEach((key) => {
-    samples[paramData[key]?.name || key] = extractSampleForParam(paramData[key], key)
+    const paramName = paramData[key]?.name || key
+    samples[paramName] = extractSampleForParam(paramData[key], paramName)
   })
   return samples
 }

--- a/src/utils/schema-example.spec.ts
+++ b/src/utils/schema-example.spec.ts
@@ -99,6 +99,47 @@ describe('extractSampleForParam', () => {
     }, 'groupNumber')).toEqual(92)
   })
 
+  it('should fall through to type-based generation when schema.examples contains null', () => {
+    expect(extractSampleForParam({
+      schema: { type: 'string', examples: [null] },
+    }, 'myParam')).toEqual('myParam')
+  })
+
+  it('should fall through to type-based generation when Stoplight examples object has value: null', () => {
+    expect(extractSampleForParam({
+      examples: [{ id: 'abc123', key: 'default', value: null }],
+      schema: { type: 'string' },
+    }, 'myParam')).toEqual('myParam')
+  })
+
+  it('should use schema.type for type-based generation when paramData.type is absent', () => {
+    expect(extractSampleForParam({ schema: { type: 'integer' } }, 'myParam')).toEqual(0)
+    expect(extractSampleForParam({ schema: { type: 'boolean' } }, 'myParam')).toEqual(false)
+    expect(extractSampleForParam({ schema: { type: 'array' } }, 'myParam')).toEqual('[]')
+  })
+
+  it('should fall through to type-based generation for full Stoplight param shape with null examples', () => {
+    expect(extractSampleForParam({
+      id: '3aea5c6215895',
+      name: 'query',
+      style: 'form',
+      examples: [{ id: '94444b275ec09', value: null, key: 'default' }],
+      description: 'The search term (can be empty).',
+      required: false,
+      schema: {
+        type: 'string',
+        examples: [null],
+      },
+    }, 'query')).toEqual('query')
+  })
+
+  it('should return empty string value from Stoplight examples object without falling through', () => {
+    expect(extractSampleForParam({
+      examples: [{ id: 'abc', key: 'default', value: '', summary: '--' }],
+      schema: { type: 'string' },
+    }, 'myParam')).toEqual('')
+  })
+
 })
 
 describe('crawl', () => {

--- a/src/utils/schema-example.ts
+++ b/src/utils/schema-example.ts
@@ -7,7 +7,12 @@ import { resolveSchemaObjectFields, resolveSchemaType } from './schema-model'
  * @param example The example to extract value from
  * @returns The extracted example value
  */
-const extractExampleValue = (example: any): any => typeof example === 'object' && example?.value ? example.value : example
+const extractExampleValue = (example: any): any => {
+  if (example !== null && typeof example === 'object' && Object.hasOwn(example, 'value')) {
+    return example.value
+  }
+  return example
+}
 
 /**
  * Returning sample value for single parameter
@@ -30,7 +35,7 @@ export const extractSampleForParam = (paramData: Record<string, any> | undefined
   if (paramData.schema?.examples) {
     exampleValue = paramData.schema?.examples[0]
     exampleValue = extractExampleValue(exampleValue)
-    if (exampleValue !== undefined) {
+    if (exampleValue !== undefined && exampleValue !== null) {
       return exampleValue
     }
   }
@@ -38,7 +43,7 @@ export const extractSampleForParam = (paramData: Record<string, any> | undefined
   if (paramData.schema?.example) {
     exampleValue = paramData.schema?.example
     exampleValue = extractExampleValue(exampleValue)
-    if (exampleValue !== undefined) {
+    if (exampleValue !== undefined && exampleValue !== null) {
       return exampleValue
     }
   }
@@ -46,10 +51,7 @@ export const extractSampleForParam = (paramData: Record<string, any> | undefined
   if (paramData.examples) {
     exampleValue = paramData.examples[0]
     exampleValue = extractExampleValue(exampleValue)
-    if (exampleValue !== undefined) {
-      return exampleValue
-    }
-    if (exampleValue !== undefined) {
+    if (exampleValue !== undefined && exampleValue !== null) {
       return exampleValue
     }
   }
@@ -66,7 +68,7 @@ export const extractSampleForParam = (paramData: Record<string, any> | undefined
     return typeof paramData.schema.default === 'object' ? JSON.stringify(paramData.schema.default) : paramData.schema.default
   }
 
-  switch (resolveSchemaType(paramData.type)) {
+  switch (resolveSchemaType(paramData.type ?? paramData.schema?.type)) {
     case 'boolean':
       return false
     case 'integer':


### PR DESCRIPTION
# Summary

  ### Problem

  Query parameters with explicitly null example values were producing incorrect or missing placeholder values in both the TryIt panel and the request sample code snippet.

  Three bugs compounded to cause this:

  **1. `extractExampleValue` misidentified Stoplight example objects with `value: null`**

  Stoplight stores examples as `{ id, key, value }` objects. The old check used `example?.value` (a truthiness test), so `{ value: null }` fell through and returned the whole object instead of `null`. This caused callers
  to receive `[object Object]` instead of a usable value.

  **2. Null example values weren't skipped — they short-circuited to `null`**

  After extraction, the guards only checked `!== undefined`. A resolved `null` satisfied that check and was returned immediately, preventing fallthrough to type-based generation (e.g. `case 'string': return key`).

  **3. `extractSample` passed array indices instead of param names to `extractSampleForParam`**

  `getSampleQuery` (called from `TryIt.vue` and `HttpOperation.vue` on mount) passes `data.request.query` — a plain array — directly to `extractSample`. `Object.keys` on an array returns `['0', '1', ...]`, so the `key` arg
   to `extractSampleForParam` was `'0'`, `'1'`, etc. The string type fallback then returned those indices as placeholder values, producing `?query=0&filter=1` in the request sample while `TryItParams` (which pre-converts
  the array to a `Record<name, param>`) correctly showed `query` and `filter`.

  Additionally, the type switch only checked `paramData.type`, but in Stoplight's format the type lives at `paramData.schema.type`, so the fallback was never reached for Stoplight params at all.

  ### Changes

  - **`extractExampleValue`**: replaced truthiness check with `Object.hasOwn(example, 'value')` so `{ value: null }` correctly extracts `null` rather than returning the whole object
  - **`extractSampleForParam`**: added `!== null` to all post-extraction guards so null examples fall through to type-based generation; added `?? paramData.schema?.type` to the type switch so Stoplight's nested type is
  resolved correctly
  - **`extractSample`**: use `paramName` (resolved from `param.name`) as both the output key and the `key` argument passed to `extractSampleForParam`, instead of the raw iteration key (which is an array index when input is
   an array)

  ### Behaviour after fix

  | Param | `examples[0].value` | Before | After |
  |---|---|---|---|
  | `query` | `null` | `null` / `0` | `"query"` |
  | `filter` | `null` | `[object Object]` / `1` | `"filter"` |
  | `test` | `""` | `""` | `""` (unchanged — explicit empty string is preserved) |

Resolves: https://konghq.atlassian.net/browse/TDX-7862

## Preview

### Broken version (current)

<img width="429" height="397" alt="image" src="https://github.com/user-attachments/assets/ac0ce303-ef11-4366-a6cc-bec918b69d53" />
<img width="429" height="397" alt="image" src="https://github.com/user-attachments/assets/ac0ce303-ef11-4366-a6cc-bec918b69d53" />


### Fixed version
<img width="951" height="616" alt="image" src="https://github.com/user-attachments/assets/75854724-9514-4d0a-86a3-13bfdd119a13" />
