### PR TITLE
fix: render default values for empty and non-empty arrays correctly [TDX-8454]

### DIFF
--- a/src/utils/schema-example.spec.ts
+++ b/src/utils/schema-example.spec.ts
@@ -249,6 +249,50 @@ describe('crawl', () => {
     })
   })
 
+  it('should render an empty array when array has no default and generic (non-object) items', () => {
+    const objData = {
+      'type': 'object',
+      'properties': {
+        'tags': {
+          'type': 'array',
+          'items': {
+            'type': 'string',
+          },
+        },
+      },
+    }
+
+    const res = crawl({ objData, filteringOptions: { excludeReadonly: false, excludeNotRequired: false } })
+    expect(res).toEqual({
+      'tags': [],
+    })
+  })
+
+  it('should generate a sample object inside the array when array has no default and object items', () => {
+    const objData = {
+      'type': 'object',
+      'properties': {
+        'items': {
+          'type': 'array',
+          'items': {
+            'type': 'object',
+            'properties': {
+              'id': { 'type': 'string' },
+              'count': { 'type': 'integer' },
+            },
+          },
+        },
+      },
+    }
+
+    const res = crawl({ objData, filteringOptions: { excludeReadonly: false, excludeNotRequired: false } })
+    expect(res).toEqual({
+      'items': [
+        { 'id': 'id', 'count': 0 },
+      ],
+    })
+  })
+
   it('TDX-5892, value from enum', () => {
 
     const objData = {

--- a/src/utils/schema-example.spec.ts
+++ b/src/utils/schema-example.spec.ts
@@ -208,6 +208,47 @@ describe('crawl', () => {
     })
   })
 
+  it('should render array default as an actual empty array, not a stringified one', () => {
+    const objData = {
+      'type': 'object',
+      'properties': {
+        'allowed_control_planes': {
+          'type': 'array',
+          'items': {
+            'type': 'string',
+            'format': 'uuid',
+          },
+          'default': [],
+        },
+      },
+    }
+
+    const res = crawl({ objData, filteringOptions: { excludeReadonly: false, excludeNotRequired: false } })
+    expect(res).toEqual({
+      'allowed_control_planes': [],
+    })
+  })
+
+  it('should render a non-empty array default as-is', () => {
+    const objData = {
+      'type': 'object',
+      'properties': {
+        'tags': {
+          'type': 'array',
+          'items': {
+            'type': 'string',
+          },
+          'default': ['a', 'b'],
+        },
+      },
+    }
+
+    const res = crawl({ objData, filteringOptions: { excludeReadonly: false, excludeNotRequired: false } })
+    expect(res).toEqual({
+      'tags': ['a', 'b'],
+    })
+  })
+
   it('TDX-5892, value from enum', () => {
 
     const objData = {

--- a/src/utils/schema-example.ts
+++ b/src/utils/schema-example.ts
@@ -215,23 +215,29 @@ export const crawl = ({ objData, parentKey = '', nestedLevel = 0, filteringOptio
 
       if (oDataType === 'array' || oDataType === 'object' || oData.allOf) {
         if (oDataType === 'array') {
-          // if it's an array of objects, we'll generate the sample array item by crawling again
-          // else, if there's no inherited fields, we'll generate the sample array item using extractSampleForParam
-          const exampleArrayItem = oData.itemType === 'object'
-            ? doCrawl({
-              objData: oData || {},
-              parentKey: key,
-              nestedLevel: nestedLevel + 1,
-              filteringOptions,
-            })
-            : crawlInheritedProperties({
-              objData: oData,
-              parentKey: key,
-              nestedLevel: nestedLevel + 1,
-              filteringOptions,
-            }) ?? extractSampleForParam(oData, key)
-          // if the exampleArrayItem is itself an array then we don't need to wrap it in an array
-          sampleObj[key] = Array.isArray(exampleArrayItem) ? exampleArrayItem : [exampleArrayItem]
+          // if the array property itself has a default value, use it as-is rather than
+          // synthesizing an item example, since the default already represents the whole array
+          if (Array.isArray(oData.default)) {
+            sampleObj[key] = oData.default
+          } else {
+            // if it's an array of objects, we'll generate the sample array item by crawling again
+            // else, if there's no inherited fields, we'll generate the sample array item using extractSampleForParam
+            const exampleArrayItem = oData.itemType === 'object'
+              ? doCrawl({
+                objData: oData || {},
+                parentKey: key,
+                nestedLevel: nestedLevel + 1,
+                filteringOptions,
+              })
+              : crawlInheritedProperties({
+                objData: oData,
+                parentKey: key,
+                nestedLevel: nestedLevel + 1,
+                filteringOptions,
+              }) ?? extractSampleForParam(oData, key)
+            // if the exampleArrayItem is itself an array then we don't need to wrap it in an array
+            sampleObj[key] = Array.isArray(exampleArrayItem) ? exampleArrayItem : [exampleArrayItem]
+          }
         } else if (oDataType === 'object' || oData.allOf) {
           const res = doCrawl({ objData: oData || {}, parentKey: key, nestedLevel: nestedLevel + 1, filteringOptions })
           if (res !== null) {

--- a/src/utils/schema-example.ts
+++ b/src/utils/schema-example.ts
@@ -235,8 +235,13 @@ export const crawl = ({ objData, parentKey = '', nestedLevel = 0, filteringOptio
                 nestedLevel: nestedLevel + 1,
                 filteringOptions,
               }) ?? extractSampleForParam(oData, key)
-            // if the exampleArrayItem is itself an array then we don't need to wrap it in an array
-            sampleObj[key] = Array.isArray(exampleArrayItem) ? exampleArrayItem : [exampleArrayItem]
+            // if the exampleArrayItem is itself an array then we don't need to wrap it in an array.
+            // extractSampleForParam falls back to the literal '[]' when the item has no example/default/enum
+            // of its own (oData.type here is always 'array', the property's own type) - in that case there's
+            // no real item to show, so render an empty array rather than wrapping the fallback string.
+            sampleObj[key] = Array.isArray(exampleArrayItem)
+              ? exampleArrayItem
+              : exampleArrayItem === '[]' ? [] : [exampleArrayItem]
           }
         } else if (oDataType === 'object' || oData.allOf) {
           const res = doCrawl({ objData: oData || {}, parentKey: key, nestedLevel: nestedLevel + 1, filteringOptions })


### PR DESCRIPTION
# Summary

ticket: https://konghq.atlassian.net/browse/TDX-8454

When a list default value is set to [], generated examples show it incorrectly as a literal string '[]'. This affects howd be updated to represent the empty list correctly rather than a string representation.