### PR TITLE
fix(styles): additional info links styles

### DIFF
--- a/src/components/common/MarkdownRenderer.vue
+++ b/src/components/common/MarkdownRenderer.vue
@@ -145,22 +145,7 @@ html.dark,
     }
 
     a {
-      color: var(--kui-color-text-primary, $kui-color-text-primary);
-      text-decoration: none;
-
-      &:hover {
-        color: var(--kui-color-text-primary-stronger, $kui-color-text-primary-stronger);
-      }
-
-      // Add external link icons
-      &[href^="http://"],
-      &[href^="https://"] {
-        background-image: url("data:image/svg+xml;base64,PHN2ZyBjbGFzcz0iaWNvbiBvdXRib3VuZCIKICB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGFyaWEtaGlkZGVuPSJ0cnVlIiBhcmlhLWxhYmVsPSIob3BlbnMgbmV3IHdpbmRvdykiIGZvY3VzYWJsZT0iZmFsc2UiIHg9IjBweCIgeT0iMHB4IiB2aWV3Qm94PSIwIDAgMTAwIDEwMCIgd2lkdGg9IjE1IiBoZWlnaHQ9IjE1Ij4KICA8cGF0aCBmaWxsPSIjYWFhIiBkPSJNMTguOCw4NS4xaDU2bDAsMGMyLjIsMCw0LTEuOCw0LTR2LTMyaC04djI4aC00OHYtNDhoMjh2LThoLTMybDAsMGMtMi4yLDAtNCwxLjgtNCw0djU2QzE0LjgsODMuMywxNi42LDg1LjEsMTguOCw4NS4xeiIgLz4KICA8cG9seWdvbiBmaWxsPSIjYWFhIiBwb2ludHM9IjQ1LjcsNDguNyA1MS4zLDU0LjMgNzcuMiwyOC41IDc3LjIsMzcuMiA4NS4yLDM3LjIgODUuMiwxNC45IDYyLjgsMTQuOSA2Mi44LDIyLjkgNzEuNSwyMi45IiAvPgo8L3N2Zz4K");
-        background-position: right center;
-        background-repeat: no-repeat;
-        background-size: 16px 16px;
-        padding-right: var(--kui-space-60, $kui-space-60);
-      }
+      @include link;
     }
 
     small {

--- a/src/components/spec-document/overview/AdditionalInfo.vue
+++ b/src/components/spec-document/overview/AdditionalInfo.vue
@@ -88,6 +88,15 @@ defineProps({
     display: block;
   }
 
+  .overview-additional-info-license[href],
+  .overview-additional-info-external-docs {
+    @include link;
+  }
+
+  .overview-additional-info-contact a {
+    @include link;
+  }
+
   > :not(:first-child) {
     margin-top: var(--kui-space-50, $kui-space-50);
   }

--- a/src/components/spec-document/overview/AdditionalInfo.vue
+++ b/src/components/spec-document/overview/AdditionalInfo.vue
@@ -86,6 +86,7 @@ defineProps({
   .overview-additional-info-external-docs,
   .overview-additional-info-contact {
     display: block;
+    width: fit-content;
   }
 
   .overview-additional-info-license[href],

--- a/src/styles/mixins/_typography.scss
+++ b/src/styles/mixins/_typography.scss
@@ -7,3 +7,23 @@
   line-height: var(--kui-line-height-40, $kui-line-height-40);
   margin: var(--kui-space-0, $kui-space-0);
 }
+
+@mixin link {
+  color: var(--kui-color-text-primary, $kui-color-text-primary);
+  text-decoration: none;
+
+  &:hover {
+    color: var(--kui-color-text-primary-stronger, $kui-color-text-primary-stronger);
+  }
+
+  // Add external link icons
+  &[href^="http://"],
+      &[href^="https://"]
+  {
+    background-image: url("data:image/svg+xml;base64,PHN2ZyBjbGFzcz0iaWNvbiBvdXRib3VuZCIKICB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGFyaWEtaGlkZGVuPSJ0cnVlIiBhcmlhLWxhYmVsPSIob3BlbnMgbmV3IHdpbmRvdykiIGZvY3VzYWJsZT0iZmFsc2UiIHg9IjBweCIgeT0iMHB4IiB2aWV3Qm94PSIwIDAgMTAwIDEwMCIgd2lkdGg9IjE1IiBoZWlnaHQ9IjE1Ij4KICA8cGF0aCBmaWxsPSIjYWFhIiBkPSJNMTguOCw4NS4xaDU2bDAsMGMyLjIsMCw0LTEuOCw0LTR2LTMyaC04djI4aC00OHYtNDhoMjh2LThoLTMybDAsMGMtMi4yLDAtNCwxLjgtNCw0djU2QzE0LjgsODMuMywxNi42LDg1LjEsMTguOCw4NS4xeiIgLz4KICA8cG9seWdvbiBmaWxsPSIjYWFhIiBwb2ludHM9IjQ1LjcsNDguNyA1MS4zLDU0LjMgNzcuMiwyOC41IDc3LjIsMzcuMiA4NS4yLDM3LjIgODUuMiwxNC45IDYyLjgsMTQuOSA2Mi44LDIyLjkgNzEuNSwyMi45IiAvPgo8L3N2Zz4K");
+    background-position: right center;
+    background-repeat: no-repeat;
+    background-size: 16px 16px;
+    padding-right: var(--kui-space-60, $kui-space-60);
+  }
+}

--- a/src/styles/mixins/_typography.scss
+++ b/src/styles/mixins/_typography.scss
@@ -18,8 +18,7 @@
 
   // Add external link icons
   &[href^="http://"],
-      &[href^="https://"]
-  {
+  &[href^="https://"] {
     background-image: url("data:image/svg+xml;base64,PHN2ZyBjbGFzcz0iaWNvbiBvdXRib3VuZCIKICB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGFyaWEtaGlkZGVuPSJ0cnVlIiBhcmlhLWxhYmVsPSIob3BlbnMgbmV3IHdpbmRvdykiIGZvY3VzYWJsZT0iZmFsc2UiIHg9IjBweCIgeT0iMHB4IiB2aWV3Qm94PSIwIDAgMTAwIDEwMCIgd2lkdGg9IjE1IiBoZWlnaHQ9IjE1Ij4KICA8cGF0aCBmaWxsPSIjYWFhIiBkPSJNMTguOCw4NS4xaDU2bDAsMGMyLjIsMCw0LTEuOCw0LTR2LTMyaC04djI4aC00OHYtNDhoMjh2LThoLTMybDAsMGMtMi4yLDAtNCwxLjgtNCw0djU2QzE0LjgsODMuMywxNi42LDg1LjEsMTguOCw4NS4xeiIgLz4KICA8cG9seWdvbiBmaWxsPSIjYWFhIiBwb2ludHM9IjQ1LjcsNDguNyA1MS4zLDU0LjMgNzcuMiwyOC41IDc3LjIsMzcuMiA4NS4yLDM3LjIgODUuMiwxNC45IDYyLjgsMTQuOSA2Mi44LDIyLjkgNzEuNSwyMi45IiAvPgo8L3N2Zz4K");
     background-position: right center;
     background-repeat: no-repeat;


### PR DESCRIPTION
# Summary

Apply link styles to links in additional information section

Before

<img width="1372" height="965" alt="Screenshot 2026-07-10 at 1 39 55 PM" src="https://github.com/user-attachments/assets/f444693d-2708-4d38-82c7-822db31cb285" />

After

<img width="1370" height="183" alt="Screenshot 2026-07-10 at 1 38 40 PM" src="https://github.com/user-attachments/assets/7752e8dc-2a27-4dcf-9897-e65dd3ee51e6" />

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
