### PR TITLE
fix: prevent serialization of nullish values in query parameters [TDX-8208]

### DIFF
--- a/src/components/spec-document/try-it/TryItParams.spec.ts
+++ b/src/components/spec-document/try-it/TryItParams.spec.ts
@@ -142,6 +142,35 @@ describe('<TryItParams />', () => {
       const expectedQuery = `page%5Bsize%5D=${exampleValues.pageSize}&page%5Bnumber%5D=${newPageNumber}`
       expect(wrapper.emitted('request-query-changed')).toEqual([[expectedQuery]])
     })
+
+    it('does not include untouched optional query parameters without examples', () => {
+      testData.props.paramType = 'query'
+      const data = structuredClone(testData.props.data)
+      data.request.query = [
+        {
+          name: 'filter',
+          required: false,
+          examples: [],
+          schema: { type: 'string' },
+        },
+        {
+          name: 'sort',
+          required: false,
+          examples: [],
+          schema: { type: 'string' },
+        },
+      ]
+
+      const wrapper = mount(TryItParams, {
+        props: {
+          ...testData.props,
+          data,
+        },
+      })
+
+      expect(wrapper.findTestId('tryit-query-param-filter-123').element).toHaveProperty('value', '')
+      expect(wrapper.findTestId('tryit-query-param-sort-123').element).toHaveProperty('value', '')
+    })
   })
 
   describe('body parameters', () => {

--- a/src/components/spec-document/try-it/TryItParams.vue
+++ b/src/components/spec-document/try-it/TryItParams.vue
@@ -317,7 +317,9 @@ watch(params, (newParams) => {
       // preserve user-edited values while on the same operation
       // but force-update when the required toggle changed, the user navigated to a different operation, or the content type switched
       if (!Object.keys(fieldValues.value).includes(key) || toggleChanged || operationChanged || contentTypeChanged) {
-        fieldValues.value[key] = samples[key]
+        // keep params without a generated sample in the same empty state as a field the user has cleared
+        // Assigning undefined here causes URLSearchParams to serialize the literal string "undefined"
+        fieldValues.value[key] = samples[key] ?? ''
       }
     })
   }

--- a/src/utils/request-data.spec.ts
+++ b/src/utils/request-data.spec.ts
@@ -160,6 +160,29 @@ describe('getSampleQuery', () => {
     })).toEqual('required=')
   })
 
+  it('does not serialize nullish field values as strings', () => {
+    const data = {
+      id: 'test-id',
+      method: 'get',
+      path: '/search',
+      request: {
+        query: [
+          { name: 'unset', required: false },
+          { name: 'missing', required: false },
+          { name: 'empty', required: false },
+          { name: 'required', required: true },
+        ],
+      },
+    }
+
+    expect(getSampleQuery(data as any, {
+      unset: undefined,
+      missing: null,
+      empty: '',
+      required: '',
+    })).toEqual('required=')
+  })
+
   it('should use param names (not array indices) for Stoplight params with null examples', () => {
     expect(getSampleQuery({
       id: '913107ebad7de',

--- a/src/utils/request-data.ts
+++ b/src/utils/request-data.ts
@@ -106,15 +106,16 @@ export const getSamplePath = (data: IHttpOperation, fieldValues?: Record<string,
  * @param fieldValues user inputs
  * @returns query string
  */
-export const getSampleQuery = (data: IHttpOperation, fieldValues?: Record<string, string> | undefined): string => {
+export const getSampleQuery = (data: IHttpOperation, fieldValues?: Record<string, string | null | undefined> | undefined): string => {
 
   const myFieldValues = fieldValues || extractSample(data.request?.query) || {}
   const urlParams = new URLSearchParams()
 
   Object.keys(myFieldValues).forEach(key => {
     const isRequired = data.request?.query?.find(r => r.name === key)?.required
-    if (isRequired || myFieldValues[key] !== '') {
-      urlParams.append(key, myFieldValues[key])
+    const value = myFieldValues[key]
+    if (value !== null && value !== undefined && (isRequired || value !== '')) {
+      urlParams.append(key, value)
     }
   })
 


### PR DESCRIPTION
# Summary

ticket: https://konghq.atlassian.net/browse/TDX-8208

this PR fixes `Try it` requests incorrectly sending untouched optional query parameters as `undefined`

optional parameters without examples now initialize as empty, and query serialization omits nullish or empty optional values