### PR TITLE
fix: prevent circular schema references from crashing [TDX-8503, TDX-8504]

### DIFF
--- a/src/components/spec-document/SpecDocument.circular-schema.spec.ts
+++ b/src/components/spec-document/SpecDocument.circular-schema.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
 import SpecDocument from './SpecDocument.vue'
+import BodyContentList from './endpoint/BodyContentList.vue'
 import { parseOpenApiSpecDocument, parsedDocument, tableOfContents } from '@/utils/schema-parser'
 import type { ServiceNode } from '@/types'
 import type { TableOfContentsItem } from '@/stoplight/elements-core'
@@ -31,7 +32,20 @@ const recursiveSchemaSpec = {
             },
           },
         },
-        responses: { 200: { description: 'ok' } },
+        // the response reuses the same circular schema so mounting this operation page also
+        // exercises ResponseSample -> hasMasking -> _schemaHasSensitiveData, the function that
+        // actually crashed in production (a fix to a different function, removeFieldsFromSchemaObject,
+        // did not cover this path - only mounting the full page here proves it's fixed)
+        responses: {
+          200: {
+            description: 'ok',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/TreeNode' },
+              },
+            },
+          },
+        },
       },
     },
   },
@@ -52,6 +66,12 @@ const recursiveSchemaSpec = {
           children: {
             type: 'array',
             items: { $ref: '#/components/schemas/TreeNode' },
+          },
+          // a oneOf variant that cycles straight back to this same schema - the shape that
+          // triggers the ModelNode/ModelProperty variant-rendering regression, which renders
+          // eagerly (unlike children above, which needs a manual "Show Child Parameters" click)
+          variant: {
+            oneOf: [{ $ref: '#/components/schemas/TreeNode' }],
           },
         },
         additionalProperties: false,
@@ -81,11 +101,26 @@ describe('<SpecDocument /> with a self-referencing (circular) schema', () => {
       })
     }).not.toThrow()
 
-    // the readOnly `internalId` field must not appear anywhere in the rendered request body,
-    // including in the schema reached by recursing back around the cycle - not just its first
-    // occurrence (a prior version of this fix only stripped readOnly fields on the first pass
-    // through a cyclic schema, and leaked them back in on subsequent laps around the cycle)
-    expect(wrapper?.text()).not.toContain('internalId')
     expect(wrapper?.text()).toContain('children')
+
+    // the readOnly `internalId` field must not appear in the rendered REQUEST body model - the
+    // request body is the first BodyContentList on the page (hide-readonly is only passed for
+    // request bodies, HttpOperation.vue) - including after recursing back around the cycle, not
+    // just its first occurrence (a prior version of this fix only stripped readOnly fields on
+    // the first pass through a cyclic schema, and leaked them back in on subsequent laps)
+    const requestBody = wrapper?.findComponent(BodyContentList)
+    expect(requestBody?.exists()).toBe(true)
+    expect(requestBody?.text()).not.toContain('internalId')
+
+    // the readOnly field IS expected to appear in the response body model, since responses are
+    // not filtered - confirms the response model actually rendered too, not just skipped
+    expect(wrapper?.text()).toContain('internalId')
+
+    // the response sample section must have actually rendered (not been skipped or left blank)
+    // proving hasMasking ran to completion on the circular schema instead of crashing before
+    // this content could ever mount - graceful degradation means already-processed content
+    // like this still displays normally even though a sibling section (the oneOf variant above)
+    // hits a cycle guard
+    expect(wrapper?.find('[data-testid="response-sample"]').exists()).toBe(true)
   })
 })

--- a/src/components/spec-document/SpecDocument.circular-schema.spec.ts
+++ b/src/components/spec-document/SpecDocument.circular-schema.spec.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import SpecDocument from './SpecDocument.vue'
+import { parseOpenApiSpecDocument, parsedDocument, tableOfContents } from '@/utils/schema-parser'
+import type { ServiceNode } from '@/types'
+import type { TableOfContentsItem } from '@/stoplight/elements-core'
+
+window.scrollTo = () => {}
+window.HTMLElement.prototype.scrollIntoView = () => {}
+
+/**
+ * A minimal OpenAPI document containing a self-referencing ("recursive") schema, e.g. a
+ * tree-shaped model whose array property references itself via `$ref`. This is a generic
+ * synthetic reproduction of a real-world recursive schema shape seen in production (a
+ * tree/section-like model referencing itself through a nested array), not a copy of any
+ * customer's actual specification. The parser's
+ * `refParser.dereference(..., { dereference: { circular: true } })` call preserves this as a
+ * live circular JS object reference rather than erroring out or truncating it.
+ */
+const recursiveSchemaSpec = {
+  openapi: '3.0.0',
+  info: { title: 'Recursive schema regression', version: '1.0.0' },
+  paths: {
+    '/nodes': {
+      post: {
+        operationId: 'submitNode',
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/TreeNode' },
+            },
+          },
+        },
+        responses: { 200: { description: 'ok' } },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      TreeNode: {
+        type: 'object',
+        required: ['id'],
+        properties: {
+          id: { type: 'string' },
+          // readOnly so we can assert it's stripped from the rendered request body schema
+          // (HttpOperation.vue passes hide-readonly for request bodies) - including after
+          // recursing back around the cycle, not just on its first occurrence
+          internalId: { type: 'string', readOnly: true },
+          // a schema referencing itself through an array property is the shape that triggers
+          // the regression: rendering the request body walks into this schema, back into
+          // itself, forever, unless the walk is cycle-safe.
+          children: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/TreeNode' },
+          },
+        },
+        additionalProperties: false,
+      },
+    },
+  },
+}
+
+describe('<SpecDocument /> with a self-referencing (circular) schema', () => {
+  it('parses and renders the operation without throwing (stack overflow / circular JSON regression)', async () => {
+    await parseOpenApiSpecDocument(JSON.stringify(recursiveSchemaSpec), {
+      currentPath: '/operations/submitNode',
+      enforceResetBeforeParsing: true,
+    })
+
+    expect(parsedDocument.value).toBeTruthy()
+
+    let wrapper: ReturnType<typeof mount> | undefined
+    expect(() => {
+      wrapper = mount(SpecDocument, {
+        props: {
+          document: parsedDocument.value as ServiceNode,
+          tableOfContents: tableOfContents.value as TableOfContentsItem[],
+          currentPath: '/operations/submitNode',
+          allowContentScrolling: false,
+        },
+      })
+    }).not.toThrow()
+
+    // the readOnly `internalId` field must not appear anywhere in the rendered request body,
+    // including in the schema reached by recursing back around the cycle - not just its first
+    // occurrence (a prior version of this fix only stripped readOnly fields on the first pass
+    // through a cyclic schema, and leaked them back in on subsequent laps around the cycle)
+    expect(wrapper?.text()).not.toContain('internalId')
+    expect(wrapper?.text()).toContain('children')
+  })
+})

--- a/src/components/spec-document/schema-model/ModelNode.spec.ts
+++ b/src/components/spec-document/schema-model/ModelNode.spec.ts
@@ -143,4 +143,41 @@ describe('<ModelNode />', () => {
       expect(wrapper.findTestId(`model-property-${kebabCase(`Variant${i}`)}`).exists()).toBe(true)
     }
   })
+
+  // the common case: a oneOf/anyOf variant is a plain schema with no oneOf/anyOf of its own.
+  // gating the variant render on the SELECTED variant having its own oneOf/anyOf (rather than on
+  // there being a selected variant at all) means this - the typical case - never renders
+  it('renders the selected oneOf variant even when the variant itself has no nested oneOf/anyOf', () => {
+    const wrapper = mount(ModelNode, {
+      props: {
+        schema: {
+          type: 'object',
+          title: 'Root',
+          oneOf: [
+            { type: 'object', title: 'PlainVariant', properties: { id: { type: 'string' } } },
+          ],
+        },
+        title: 'Root',
+      },
+    })
+
+    expect(wrapper.findTestId(`model-property-${kebabCase('PlainVariant')}`).exists()).toBe(true)
+  })
+
+  it('renders the selected anyOf variant even when the variant itself has no nested oneOf/anyOf', () => {
+    const wrapper = mount(ModelNode, {
+      props: {
+        schema: {
+          type: 'object',
+          title: 'Root',
+          anyOf: [
+            { type: 'object', title: 'PlainVariant', properties: { id: { type: 'string' } } },
+          ],
+        },
+        title: 'Root',
+      },
+    })
+
+    expect(wrapper.findTestId(`model-property-${kebabCase('PlainVariant')}`).exists()).toBe(true)
+  })
 })

--- a/src/components/spec-document/schema-model/ModelNode.spec.ts
+++ b/src/components/spec-document/schema-model/ModelNode.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { shallowMount } from '@vue/test-utils'
+import { shallowMount, mount } from '@vue/test-utils'
 import ModelNode from './ModelNode.vue'
 import type { SchemaObject } from '@/types'
 
@@ -56,5 +56,40 @@ describe('<ModelNode />', () => {
     for (const property in schema.properties) {
       expect(wrapper.findTestId(`model-property-${property}`).exists()).toBe(true)
     }
+  })
+
+  // a schema whose oneOf/anyOf variants cycle back to an ancestor renders eagerly (unlike
+  // nested properties, which need a manual "Show Child Parameters" click), so without a
+  // recursion cap this would mount ModelNode/ModelProperty forever and crash the tab
+  it('does not recurse forever when oneOf variants form a cycle', () => {
+    const schemaA: SchemaObject = { type: 'object', title: 'A' }
+    const schemaB: SchemaObject = { type: 'object', title: 'B' }
+    schemaA.oneOf = [schemaB]
+    schemaB.oneOf = [schemaA]
+
+    expect(() => {
+      mount(ModelNode, {
+        props: {
+          schema: schemaA,
+          title: 'A',
+        },
+      })
+    }).not.toThrow()
+  })
+
+  it('does not recurse forever when anyOf variants form a cycle', () => {
+    const schemaA: SchemaObject = { type: 'object', title: 'A' }
+    const schemaB: SchemaObject = { type: 'object', title: 'B' }
+    schemaA.anyOf = [schemaB]
+    schemaB.anyOf = [schemaA]
+
+    expect(() => {
+      mount(ModelNode, {
+        props: {
+          schema: schemaA,
+          title: 'A',
+        },
+      })
+    }).not.toThrow()
   })
 })

--- a/src/components/spec-document/schema-model/ModelNode.spec.ts
+++ b/src/components/spec-document/schema-model/ModelNode.spec.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from 'vitest'
 import { shallowMount, mount } from '@vue/test-utils'
 import ModelNode from './ModelNode.vue'
+import ModelProperty from './ModelProperty.vue'
 import type { SchemaObject } from '@/types'
+import { kebabCase } from '@/utils'
 
 describe('<ModelNode />', () => {
   // test for a simple model with properties
@@ -91,5 +93,54 @@ describe('<ModelNode />', () => {
         },
       })
     }).not.toThrow()
+  })
+
+  // the ancestor-chain guard should stop exactly at the repeated schema, not merely somewhere
+  // before an arbitrary depth backstop - so a 2-node cycle should render each schema once, not
+  // loop around several times before the backstop catches it
+  it('stops at the exact repeat rather than looping until a depth backstop is hit', () => {
+    const schemaA: SchemaObject = { type: 'object', title: 'A' }
+    const schemaB: SchemaObject = { type: 'object', title: 'B' }
+    schemaA.oneOf = [schemaB]
+    schemaB.oneOf = [schemaA]
+
+    const wrapper = mount(ModelNode, {
+      props: {
+        schema: schemaA,
+        title: 'A',
+      },
+    })
+
+    // A renders once (top-level ModelNode's variant branch renders schema B, which then tries
+    // to render A again as its own variant - that repeat is where the guard must stop)
+    expect(wrapper.findAllComponents(ModelProperty).length).toBe(1)
+    expect(wrapper.findTestId(`model-property-${kebabCase('B')}`).exists()).toBe(true)
+  })
+
+  // a legitimately deep, non-circular chain of distinct oneOf variants must render in full -
+  // proving the ancestor-chain guard (which only stops on an actual repeat) doesn't truncate
+  // valid content the way a blunt depth cap would
+  it('fully renders a long chain of distinct oneOf variants with no repeats', () => {
+    const CHAIN_LENGTH = 20
+    const schemas: SchemaObject[] = Array.from({ length: CHAIN_LENGTH }, (_, i) => ({
+      type: 'object',
+      title: `Variant${i}`,
+    }))
+    schemas.forEach((schema, i) => {
+      if (i < schemas.length - 1) {
+        schema.oneOf = [schemas[i + 1]]
+      }
+    })
+
+    const wrapper = mount(ModelNode, {
+      props: {
+        schema: schemas[0],
+        title: 'Variant0',
+      },
+    })
+
+    for (let i = 1; i < CHAIN_LENGTH; i++) {
+      expect(wrapper.findTestId(`model-property-${kebabCase(`Variant${i}`)}`).exists()).toBe(true)
+    }
   })
 })

--- a/src/components/spec-document/schema-model/ModelNode.spec.ts
+++ b/src/components/spec-document/schema-model/ModelNode.spec.ts
@@ -145,9 +145,12 @@ describe('<ModelNode />', () => {
   })
 
   // the common case: a oneOf/anyOf variant is a plain schema with no oneOf/anyOf of its own.
-  // gating the variant render on the SELECTED variant having its own oneOf/anyOf (rather than on
-  // there being a selected variant at all) means this - the typical case - never renders
-  it('renders the selected oneOf variant even when the variant itself has no nested oneOf/anyOf', () => {
+  // ModelNode has two sibling render blocks - a wrapped variant render, and a flat "properties" loop
+  // that renders selectedSchemaModel's own properties directly. When the selected variant is a plain
+  // object with properties, both blocks previously rendered the same field: once wrapped (labeled with
+  // the variant's own name), once again flat - a visible duplication. The wrapped block should be
+  // skipped for this shape; the flat "properties" loop already renders the field on its own.
+  it('renders the selected oneOf variant\'s properties without a redundant wrapper', () => {
     const wrapper = mount(ModelNode, {
       props: {
         schema: {
@@ -161,10 +164,14 @@ describe('<ModelNode />', () => {
       },
     })
 
-    expect(wrapper.findTestId(`model-property-${kebabCase('PlainVariant')}`).exists()).toBe(true)
+    // the field renders once, via the flat properties loop
+    expect(wrapper.findTestId('model-property-id').exists()).toBe(true)
+    // the wrapped variant render (labeled with the variant's own name) must not also render it
+    expect(wrapper.findTestId(`model-property-${kebabCase('PlainVariant')}`).exists()).toBe(false)
+    expect(wrapper.findAllComponents(ModelProperty).length).toBe(1)
   })
 
-  it('renders the selected anyOf variant even when the variant itself has no nested oneOf/anyOf', () => {
+  it('renders the selected anyOf variant\'s properties without a redundant wrapper', () => {
     const wrapper = mount(ModelNode, {
       props: {
         schema: {
@@ -178,6 +185,93 @@ describe('<ModelNode />', () => {
       },
     })
 
-    expect(wrapper.findTestId(`model-property-${kebabCase('PlainVariant')}`).exists()).toBe(true)
+    expect(wrapper.findTestId('model-property-id').exists()).toBe(true)
+    expect(wrapper.findTestId(`model-property-${kebabCase('PlainVariant')}`).exists()).toBe(false)
+    expect(wrapper.findAllComponents(ModelProperty).length).toBe(1)
+  })
+
+  // reproduces the reported production bug: a oneOf between a primitive variant (no properties, no
+  // further oneOf/anyOf) and an object variant with plain properties (no further oneOf/anyOf either).
+  // the default-selected (first) variant must render correctly for either shape - a primitive
+  // variant renders nothing extra (its type is conveyed by whatever wraps this ModelNode), and an
+  // object variant's property must render exactly once, not duplicated
+  it('renders nothing extra when the default-selected variant is a primitive (StringFieldFilter-shaped schema)', () => {
+    const stringFieldEqualsFilter: SchemaObject = { type: 'string', title: 'StringFieldEqualsFilter' }
+    const stringFieldContainsFilter: SchemaObject = {
+      type: 'object',
+      title: 'StringFieldContainsFilter',
+      properties: { contains: { type: 'string' } },
+      required: ['contains'],
+    }
+    const wrapper = mount(ModelNode, {
+      props: {
+        schema: {
+          type: 'object',
+          title: 'StringFieldFilter',
+          oneOf: [stringFieldEqualsFilter, stringFieldContainsFilter],
+        },
+        title: 'StringFieldFilter',
+      },
+    })
+
+    expect(wrapper.findAllComponents(ModelProperty).length).toBe(0)
+  })
+
+  it('does not duplicate a plain object variant\'s properties (StringFieldFilter-shaped schema)', () => {
+    const stringFieldEqualsFilter: SchemaObject = { type: 'string', title: 'StringFieldEqualsFilter' }
+    const stringFieldContainsFilter: SchemaObject = {
+      type: 'object',
+      title: 'StringFieldContainsFilter',
+      properties: { contains: { type: 'string' } },
+      required: ['contains'],
+    }
+    const wrapper = mount(ModelNode, {
+      props: {
+        schema: {
+          type: 'object',
+          title: 'StringFieldFilter',
+          // object variant first, so it's the default selection - no dropdown interaction needed
+          oneOf: [stringFieldContainsFilter, stringFieldEqualsFilter],
+        },
+        title: 'StringFieldFilter',
+      },
+    })
+
+    expect(wrapper.findTestId('model-property-contains').exists()).toBe(true)
+    expect(wrapper.findTestId(`model-property-${kebabCase('StringFieldContainsFilter')}`).exists()).toBe(false)
+    expect(wrapper.findAllComponents(ModelProperty).length).toBe(1)
+  })
+
+  // oneOf/anyOf can be hidden inside a variant's allOf and only surface after allOf-merge
+  // resolution. Gating the wrapped render on the RAW variant's oneOf/anyOf (rather than the
+  // resolved form) would miss this and silently drop the nested variant and its fields.
+  it('still renders a variant whose oneOf is hidden inside its own allOf', () => {
+    const inner: SchemaObject = {
+      type: 'object',
+      title: 'Inner',
+      properties: { x: { type: 'string' } },
+    }
+    const variantWithHiddenOneOf: SchemaObject = {
+      type: 'object',
+      title: 'VariantWithHiddenOneOf',
+      allOf: [{ oneOf: [inner] }],
+    }
+    const wrapper = mount(ModelNode, {
+      props: {
+        schema: {
+          type: 'object',
+          title: 'Root',
+          oneOf: [variantWithHiddenOneOf],
+        },
+        title: 'Root',
+      },
+    })
+
+    // the variant renders wrapped (correct: it does have further oneOf/anyOf once resolved), and
+    // recursion correctly surfaces the nested "Inner" variant it resolves to - proving the allOf
+    // wrapping wasn't silently dropped. "Inner"'s own nested properties aren't asserted here: those
+    // are gated behind a manual "Show Child Parameters" expand, unrelated to this oneOf/allOf case.
+    expect(wrapper.findTestId(`model-property-${kebabCase('VariantWithHiddenOneOf')}`).exists()).toBe(true)
+    expect(wrapper.findTestId(`model-property-${kebabCase('Inner')}`).exists()).toBe(true)
   })
 })

--- a/src/components/spec-document/schema-model/ModelNode.vue
+++ b/src/components/spec-document/schema-model/ModelNode.vue
@@ -19,7 +19,7 @@
       </div>
       <!-- if the schema model has variants, render the selected variant -->
       <ModelProperty
-        v-if="(selectedSchemaModel?.oneOf || selectedSchemaModel?.anyOf) && !isCircularVariant && !variantRecursionLimitReached"
+        v-if="rawSelectedVariant && !isCircularVariant && !variantRecursionLimitReached"
         :ancestor-schemas="ancestorsIncludingSelf"
         :base-path-id="basePathId"
         :depth="depth"

--- a/src/components/spec-document/schema-model/ModelNode.vue
+++ b/src/components/spec-document/schema-model/ModelNode.vue
@@ -19,10 +19,11 @@
       </div>
       <!-- if the schema model has variants, render the selected variant -->
       <ModelProperty
-        v-if="(selectedSchemaModel?.oneOf || selectedSchemaModel?.anyOf) && !variantRecursionLimitReached"
+        v-if="(selectedSchemaModel?.oneOf || selectedSchemaModel?.anyOf) && !isCircularVariant && !variantRecursionLimitReached"
+        :ancestor-schemas="ancestorsIncludingSelf"
         :base-path-id="basePathId"
         :depth="depth"
-        :property="selectedSchemaModel"
+        :property="rawSelectedVariant!"
         :property-name="selectedSchemaModel.title || variantSelectItemList[selectedVariantIndex]?.label || ''"
         :required-fields="selectedSchemaModel?.required"
         :variant-depth="variantDepth + 1"
@@ -36,6 +37,7 @@
     >
       <ModelProperty
         v-if="isValidSchemaObject(property)"
+        :ancestor-schemas="ancestorsIncludingSelf"
         :base-path-id="basePathId"
         :class="{ 'model-node-property': index !== 0 }"
         :data-testid="`model-property-${propertyName}`"
@@ -55,7 +57,7 @@ import type { PropType } from 'vue'
 import ModelProperty from './ModelProperty.vue'
 import SelectDropdown from '@/components/common/SelectDropdown.vue'
 import type { SchemaObject, SelectItem } from '@/types'
-import { isValidSchemaObject, resolveSchemaObjectFields } from '@/utils'
+import { isValidSchemaObject } from '@/utils'
 import useSchemaVariants from '@/composables/useSchemaVariants'
 import VariantLabel from '@/components/common/VariantLabel.vue'
 import { MAX_VARIANT_RECURSION_DEPTH } from '@/constants'
@@ -92,20 +94,32 @@ const props = defineProps({
     default: 1,
   },
   /**
-   * How many oneOf/anyOf variant hops deep the current node is.
-   * Unlike nested properties (gated behind a manual "Show Child Parameters" click),
-   * variants render eagerly, so a circular schema needs this counter to stop recursion.
+   * Variant recursion depth backstop - see MAX_VARIANT_RECURSION_DEPTH.
    */
   variantDepth: {
     type: Number,
     default: 0,
   },
+  /**
+   * Ancestor schemas already visited in this render chain - see useSchemaVariants.
+   */
+  ancestorSchemas: {
+    type: Object as PropType<Set<object>>,
+    default: () => new Set<object>(),
+  },
 })
 
 const variantRecursionLimitReached = computed(() => props.variantDepth >= MAX_VARIANT_RECURSION_DEPTH)
 
-const resolvedSchemaObject = computed(() => resolveSchemaObjectFields(props.schema))
-const { variantSelectItemList, selectedSchemaModel, selectedVariantIndex, inheritanceTypeLabel } = useSchemaVariants(resolvedSchemaObject)
+const {
+  variantSelectItemList,
+  selectedSchemaModel,
+  selectedVariantIndex,
+  inheritanceTypeLabel,
+  rawSelectedVariant,
+  isCircularVariant,
+  ancestorsIncludingSelf,
+} = useSchemaVariants(computed(() => props.schema), computed(() => props.ancestorSchemas))
 
 function handleVariantSelectChange(selecteditem: SelectItem) {
   selectedVariantIndex.value = Number(selecteditem.value)

--- a/src/components/spec-document/schema-model/ModelNode.vue
+++ b/src/components/spec-document/schema-model/ModelNode.vue
@@ -19,12 +19,13 @@
       </div>
       <!-- if the schema model has variants, render the selected variant -->
       <ModelProperty
-        v-if="selectedSchemaModel?.oneOf || selectedSchemaModel?.anyOf"
+        v-if="(selectedSchemaModel?.oneOf || selectedSchemaModel?.anyOf) && !variantRecursionLimitReached"
         :base-path-id="basePathId"
         :depth="depth"
         :property="selectedSchemaModel"
         :property-name="selectedSchemaModel.title || variantSelectItemList[selectedVariantIndex]?.label || ''"
         :required-fields="selectedSchemaModel?.required"
+        :variant-depth="variantDepth + 1"
       />
     </template>
 
@@ -42,6 +43,7 @@
         :property="property"
         :property-name="propertyName.toString()"
         :required-fields="selectedSchemaModel?.required"
+        :variant-depth="variantDepth"
       />
     </template>
   </div>
@@ -56,6 +58,7 @@ import type { SchemaObject, SelectItem } from '@/types'
 import { isValidSchemaObject, resolveSchemaObjectFields } from '@/utils'
 import useSchemaVariants from '@/composables/useSchemaVariants'
 import VariantLabel from '@/components/common/VariantLabel.vue'
+import { MAX_VARIANT_RECURSION_DEPTH } from '@/constants'
 
 const props = defineProps({
   schema: {
@@ -88,7 +91,18 @@ const props = defineProps({
     type: Number,
     default: 1,
   },
+  /**
+   * How many oneOf/anyOf variant hops deep the current node is.
+   * Unlike nested properties (gated behind a manual "Show Child Parameters" click),
+   * variants render eagerly, so a circular schema needs this counter to stop recursion.
+   */
+  variantDepth: {
+    type: Number,
+    default: 0,
+  },
 })
+
+const variantRecursionLimitReached = computed(() => props.variantDepth >= MAX_VARIANT_RECURSION_DEPTH)
 
 const resolvedSchemaObject = computed(() => resolveSchemaObjectFields(props.schema))
 const { variantSelectItemList, selectedSchemaModel, selectedVariantIndex, inheritanceTypeLabel } = useSchemaVariants(resolvedSchemaObject)

--- a/src/components/spec-document/schema-model/ModelNode.vue
+++ b/src/components/spec-document/schema-model/ModelNode.vue
@@ -19,7 +19,7 @@
       </div>
       <!-- if the schema model has variants, render the selected variant -->
       <ModelProperty
-        v-if="rawSelectedVariant && !isCircularVariant && !variantRecursionLimitReached"
+        v-if="(selectedSchemaModel?.oneOf || selectedSchemaModel?.anyOf) && !isCircularVariant && !variantRecursionLimitReached"
         :ancestor-schemas="ancestorsIncludingSelf"
         :base-path-id="basePathId"
         :depth="depth"

--- a/src/components/spec-document/schema-model/ModelProperty.spec.ts
+++ b/src/components/spec-document/schema-model/ModelProperty.spec.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
+import { ref } from 'vue'
 import ModelProperty from './ModelProperty.vue'
+import ModelNode from './ModelNode.vue'
 import type { SchemaObject } from '@/types'
 import { kebabCase } from '@/utils'
 
@@ -140,5 +142,40 @@ describe('<ModelProperty />', () => {
       // Check if ModelProperty component renders for the first anyOf object
       expect(wrapper.findTestId(`model-property-${kebabCase(anyOfList[0].title ?? '')}`).exists()).toBe(true)
     })
+  })
+
+  // when a variant is blocked as circular, the sibling `v-else-if="nestedPropertiesPresent"`
+  // branch must not fall through and re-render the very same schema via a fresh ModelNode -
+  // that bypasses the guard entirely (it only re-triggers one hop later) and, with a
+  // config'd maxExpandedDepth above 1, mounts several duplicate copies of the same node before
+  // depth (not the cycle guard) finally stops it
+  it('does not fall through to re-render nested properties when a variant is blocked as circular', () => {
+    const treeNode: SchemaObject = {
+      type: 'object',
+      title: 'TreeNode',
+      properties: {
+        id: { type: 'string' },
+      },
+    }
+    // a nested property whose own oneOf cycles back to the root schema - the guard blocks this
+    // variant, and the bug was in what happens next on this same ModelProperty
+    const variant: SchemaObject = { oneOf: [treeNode] }
+    treeNode.properties!.variant = variant
+
+    const wrapper = mount(ModelProperty, {
+      props: {
+        property: treeNode,
+        propertyName: 'root',
+      },
+      global: {
+        provide: {
+          'max-expanded-depth': ref(5),
+        },
+      },
+    })
+
+    // only the single ModelNode rendered for the root schema's own properties should exist -
+    // not further duplicates of the same schema re-entered through the blocked variant
+    expect(wrapper.findAllComponents(ModelNode).length).toBe(1)
   })
 })

--- a/src/components/spec-document/schema-model/ModelProperty.vue
+++ b/src/components/spec-document/schema-model/ModelProperty.vue
@@ -16,7 +16,7 @@
     />
 
     <div
-      v-if="variantSelectItemList.length"
+      v-if="variantSelectItemList.length && !variantRecursionLimitReached"
       class="selected-variant-container"
     >
       <ModelProperty
@@ -25,6 +25,7 @@
         :property="selectedSchemaModel"
         :property-name="selectedSchemaModel.title || variantSelectItemList[selectedVariantIndex]?.label || ''"
         :required-fields="selectedSchemaModel.required"
+        :variant-depth="variantDepth + 1"
       />
     </div>
 
@@ -50,6 +51,7 @@
         :depth="depth + 1"
         :schema="selectedSchemaModel"
         :title="propertyName"
+        :variant-depth="variantDepth"
       />
     </details>
   </div>
@@ -65,7 +67,7 @@ import type { SchemaObject } from '@/types'
 import ModelNode from './ModelNode.vue'
 import useSchemaVariants from '@/composables/useSchemaVariants'
 import PropertyFieldList from './PropertyFieldList.vue'
-import { DEFAULT_EXPANDED_PROPERTIES_DEPTH } from '@/constants'
+import { DEFAULT_EXPANDED_PROPERTIES_DEPTH, MAX_VARIANT_RECURSION_DEPTH } from '@/constants'
 
 const props = defineProps({
   property: {
@@ -94,9 +96,19 @@ const props = defineProps({
     type: Number,
     default: 1,
   },
+  /**
+   * How many oneOf/anyOf variant hops deep the current property is.
+   * Unlike nested properties (gated behind a manual "Show Child Parameters" click),
+   * variants render eagerly, so a circular schema needs this counter to stop recursion.
+   */
+  variantDepth: {
+    type: Number,
+    default: 0,
+  },
 })
 
 const maxExpandedDepth = inject<Ref<number>>('max-expanded-depth', ref(DEFAULT_EXPANDED_PROPERTIES_DEPTH))
+const variantRecursionLimitReached = computed(() => props.variantDepth >= MAX_VARIANT_RECURSION_DEPTH)
 
 const nestedPropertiesExpanded = ref(props.depth < maxExpandedDepth.value)
 

--- a/src/components/spec-document/schema-model/ModelProperty.vue
+++ b/src/components/spec-document/schema-model/ModelProperty.vue
@@ -16,13 +16,14 @@
     />
 
     <div
-      v-if="variantSelectItemList.length && !variantRecursionLimitReached"
+      v-if="variantSelectItemList.length && !isCircularVariant && !variantRecursionLimitReached"
       class="selected-variant-container"
     >
       <ModelProperty
+        :ancestor-schemas="ancestorsIncludingSelf"
         :base-path-id="propertyId"
         :depth="depth"
-        :property="selectedSchemaModel"
+        :property="rawSelectedVariant!"
         :property-name="selectedSchemaModel.title || variantSelectItemList[selectedVariantIndex]?.label || ''"
         :required-fields="selectedSchemaModel.required"
         :variant-depth="variantDepth + 1"
@@ -30,7 +31,7 @@
     </div>
 
     <details
-      v-else-if="nestedPropertiesPresent"
+      v-else-if="nestedPropertiesPresent && !isCircularVariant && !variantRecursionLimitReached"
       ref="nestedFields"
     >
       <summary
@@ -46,6 +47,7 @@
       </summary>
       <ModelNode
         v-if="nestedPropertiesExpanded"
+        :ancestor-schemas="ancestorsIncludingSelf"
         :base-path-id="propertyId"
         class="nested-model-node"
         :depth="depth + 1"
@@ -60,7 +62,7 @@
 <script setup lang="ts">
 import { computed, inject, onMounted, ref, useTemplateRef } from 'vue'
 import { AddIcon } from '@kong/icons'
-import { isSsr, kebabCase, resolveSchemaObjectFields } from '@/utils'
+import { isSsr, kebabCase } from '@/utils'
 import type { PropType, Ref } from 'vue'
 import type { SchemaObject } from '@/types'
 
@@ -97,13 +99,18 @@ const props = defineProps({
     default: 1,
   },
   /**
-   * How many oneOf/anyOf variant hops deep the current property is.
-   * Unlike nested properties (gated behind a manual "Show Child Parameters" click),
-   * variants render eagerly, so a circular schema needs this counter to stop recursion.
+   * Variant recursion depth backstop - see MAX_VARIANT_RECURSION_DEPTH.
    */
   variantDepth: {
     type: Number,
     default: 0,
+  },
+  /**
+   * Ancestor schemas already visited in this render chain - see useSchemaVariants.
+   */
+  ancestorSchemas: {
+    type: Object as PropType<Set<object>>,
+    default: () => new Set<object>(),
   },
 })
 
@@ -118,13 +125,16 @@ const nestedFieldsDetails = useTemplateRef('nestedFields')
 const dataTestId = computed(() => `model-property-${kebabCase(props.propertyName)}`)
 const propertyId = computed(() => props.basePathId ? kebabCase(`${props.basePathId}-${props.propertyName}`) : undefined)
 
-const resolvedSchemaObject = computed(() => resolveSchemaObjectFields(props.property))
 const {
+  resolvedSchemaObject,
   variantSelectItemList,
   selectedSchemaModel,
   selectedVariantIndex,
   inheritanceTypeLabel,
-} = useSchemaVariants(resolvedSchemaObject)
+  rawSelectedVariant,
+  isCircularVariant,
+  ancestorsIncludingSelf,
+} = useSchemaVariants(computed(() => props.property), computed(() => props.ancestorSchemas))
 
 const nestedPropertiesPresent = computed<boolean>(() => {
   if (selectedSchemaModel.value?.properties) {

--- a/src/components/spec-document/schema-model/ModelProperty.vue
+++ b/src/components/spec-document/schema-model/ModelProperty.vue
@@ -16,7 +16,7 @@
     />
 
     <div
-      v-if="variantSelectItemList.length && !isCircularVariant && !variantRecursionLimitReached"
+      v-if="rawSelectedVariant && !isCircularVariant && !variantRecursionLimitReached"
       class="selected-variant-container"
     >
       <ModelProperty

--- a/src/composables/useSchemaVariants.spec.ts
+++ b/src/composables/useSchemaVariants.spec.ts
@@ -141,4 +141,44 @@ describe('useSchemaVariants', () => {
       expect(selectedSchemaModel.value).toEqual(schemaList[1])
     })
   })
+
+  describe('cycle detection', () => {
+    it('is not circular when there is no ancestor overlap', () => {
+      const schemaA: SchemaObject = { type: 'object', title: 'A', oneOf: [{ type: 'object', title: 'B' }] }
+      const { isCircularVariant, rawSelectedVariant } = useSchemaVariants(computed(() => schemaA))
+      expect(isCircularVariant.value).toBe(false)
+      expect(rawSelectedVariant.value?.title).toBe('B')
+    })
+
+    it('detects a direct self-reference immediately', () => {
+      const schemaA: SchemaObject = { type: 'object', title: 'A' }
+      schemaA.oneOf = [schemaA]
+      const { isCircularVariant } = useSchemaVariants(computed(() => schemaA))
+      expect(isCircularVariant.value).toBe(true)
+    })
+
+    // resolveSchemaObjectFields returns a freshly-copied object for array-typed schemas (to hoist
+    // the items' fields up), so a cycle running back through an array-typed intermediate variant
+    // can only be detected by tracking each level's raw (pre-resolve) schema, not the resolved
+    // selectedSchemaModel - this is the same identity-breaking shape found in crawl() and
+    // _schemaHasSensitiveData, reproduced here at the composable level
+    it('detects a cycle running back through an array-typed intermediate variant', () => {
+      const variantArr: SchemaObject = { type: 'array', items: {} }
+      variantArr.items = { type: 'object', oneOf: [variantArr] }
+      const schemaA: SchemaObject = { type: 'object', title: 'A', oneOf: [variantArr] }
+
+      // level 1: root schema, selects variantArr as its variant
+      const root = useSchemaVariants(computed(() => schemaA))
+      expect(root.isCircularVariant.value).toBe(false)
+      expect(root.rawSelectedVariant.value).toBe(variantArr)
+
+      // level 2: descends into variantArr itself, using the raw identity + ancestor set a
+      // recursive render would pass down - variantArr's own (hoisted) oneOf points back to itself
+      const level2 = useSchemaVariants(
+        computed(() => root.rawSelectedVariant.value as SchemaObject),
+        computed(() => root.ancestorsIncludingSelf.value),
+      )
+      expect(level2.isCircularVariant.value).toBe(true)
+    })
+  })
 })

--- a/src/composables/useSchemaVariants.spec.ts
+++ b/src/composables/useSchemaVariants.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import useSchemaVariants from './useSchemaVariants'
-import { computed } from 'vue'
+import { computed, nextTick, ref } from 'vue'
 import type { SchemaObject } from '@/types'
 
 const schemaList: SchemaObject[] = [
@@ -179,6 +179,68 @@ describe('useSchemaVariants', () => {
         computed(() => root.ancestorsIncludingSelf.value),
       )
       expect(level2.isCircularVariant.value).toBe(true)
+    })
+  })
+
+  describe('stale selectedVariantIndex', () => {
+    // the underlying schema prop can change on an already-mounted instance without remounting
+    // (e.g. a parent's own variant selection changes what it passes down). If the new variant
+    // list is shorter than the old one, a previously-selected index can point past its end -
+    // rawSelectedVariant must not silently go undefined while variantSelectItemList.length still
+    // looks non-empty
+    it('resets the selected index when the variant list shrinks below it', async () => {
+      const schema = ref<SchemaObject>({
+        type: 'object',
+        oneOf: [
+          { type: 'object', title: 'A' },
+          { type: 'object', title: 'B' },
+          { type: 'object', title: 'C' },
+        ],
+      })
+
+      const { selectedVariantIndex, rawSelectedVariant, variantSelectItemList } = useSchemaVariants(computed(() => schema.value))
+      selectedVariantIndex.value = 2
+      expect(rawSelectedVariant.value?.title).toBe('C')
+
+      // schema changes to a shorter variant list; index 2 is now out of range
+      schema.value = {
+        type: 'object',
+        oneOf: [
+          { type: 'object', title: 'X' },
+        ],
+      }
+      await nextTick()
+
+      expect(selectedVariantIndex.value).toBe(0)
+      expect(rawSelectedVariant.value).toBeDefined()
+      expect(rawSelectedVariant.value?.title).toBe('X')
+      expect(variantSelectItemList.value.length).toBe(1)
+    })
+
+    it('leaves the selected index alone when it is still in range', async () => {
+      const schema = ref<SchemaObject>({
+        type: 'object',
+        oneOf: [
+          { type: 'object', title: 'A' },
+          { type: 'object', title: 'B' },
+        ],
+      })
+
+      const { selectedVariantIndex, rawSelectedVariant } = useSchemaVariants(computed(() => schema.value))
+      selectedVariantIndex.value = 1
+
+      // the variant list still has at least 2 entries, so index 1 remains valid
+      schema.value = {
+        type: 'object',
+        oneOf: [
+          { type: 'object', title: 'X' },
+          { type: 'object', title: 'Y' },
+        ],
+      }
+      await nextTick()
+
+      expect(selectedVariantIndex.value).toBe(1)
+      expect(rawSelectedVariant.value?.title).toBe('Y')
     })
   })
 })

--- a/src/composables/useSchemaVariants.ts
+++ b/src/composables/useSchemaVariants.ts
@@ -1,5 +1,5 @@
 // composable to manage schema variants for oneOf/anyOf
-import { computed, ref, unref, type ComputedRef, type Ref } from 'vue'
+import { computed, ref, unref, watch, type ComputedRef, type Ref } from 'vue'
 import type { SchemaObject, SelectItem } from '@/types'
 import { inheritedPropertyName, isValidSchemaObject, resolveSchemaObjectFields } from '@/utils'
 
@@ -47,6 +47,18 @@ export default function useSchemaVariants(
 
   // ref to store the index of the selected variant
   const selectedVariantIndex = ref<number>(0)
+
+  // the underlying schema can change on an already-mounted instance (e.g. a parent variant
+  // selection changes what gets passed down), which can leave selectedVariantIndex pointing
+  // past the end of the new, possibly shorter, variant list - reset it rather than let
+  // rawSelectedVariant silently go undefined while variantSelectItemList.length still passes
+  watch(rawVariantList, (list) => {
+    if (selectedVariantIndex.value >= list.length) {
+      selectedVariantIndex.value = 0
+    }
+  })
+
+
   /**
    * If the schema model has variants, it returns the selected variant, else it returns the schema model itself
    */

--- a/src/composables/useSchemaVariants.ts
+++ b/src/composables/useSchemaVariants.ts
@@ -1,23 +1,35 @@
 // composable to manage schema variants for oneOf/anyOf
-import { computed, ref, type ComputedRef } from 'vue'
+import { computed, ref, unref, type ComputedRef, type Ref } from 'vue'
 import type { SchemaObject, SelectItem } from '@/types'
 import { inheritedPropertyName, isValidSchemaObject, resolveSchemaObjectFields } from '@/utils'
 
-export default function useSchemaVariants(schemaModel: ComputedRef<SchemaObject>) {
+/**
+ * @param rawSchema The schema to compute variants from, pre-resolve (resolved internally)
+ * @param ancestorSchemas Raw ancestor schemas already visited in this render chain, for
+ * detecting a oneOf/anyOf variant that cycles back to an ancestor. Must stay keyed on raw
+ * (pre-resolve) objects - resolveSchemaObjectFields copies array/allOf schemas on every call,
+ * so keying on its output would give a revisited schema a new identity each time.
+ */
+export default function useSchemaVariants(
+  rawSchema: ComputedRef<SchemaObject> | Ref<SchemaObject>,
+  ancestorSchemas: Ref<Set<object>> | ComputedRef<Set<object>> = ref(new Set()),
+) {
+  const resolvedSchemaObject = computed(() => resolveSchemaObjectFields(unref(rawSchema)))
+
   const inheritanceTypeLabel = computed(() =>
-    schemaModel.value?.oneOf?.length
+    resolvedSchemaObject.value?.oneOf?.length
       ? 'One Of'
-      : schemaModel.value?.anyOf?.length
+      : resolvedSchemaObject.value?.anyOf?.length
         ? 'Any Of'
         : '',
   )
 
-  // get the list of variants, from oneOf or anyOf, or an empty array in case neither are present
-  const schemaVariantList = computed(() =>
-    (schemaModel.value?.oneOf || schemaModel.value?.anyOf || []).filter(
-      isValidSchemaObject,
-    ).map(resolveSchemaObjectFields),
+  // raw (pre-resolve) variants from oneOf/anyOf, filtered - same indices as schemaVariantList below
+  const rawVariantList = computed((): SchemaObject[] =>
+    (resolvedSchemaObject.value?.oneOf || resolvedSchemaObject.value?.anyOf || []).filter(isValidSchemaObject),
   )
+
+  const schemaVariantList = computed(() => rawVariantList.value.map(resolveSchemaObjectFields))
 
   /**
    * If the schema model has variants, it returns the list of variants, else it returns an empty array
@@ -40,13 +52,33 @@ export default function useSchemaVariants(schemaModel: ComputedRef<SchemaObject>
    */
   const selectedSchemaModel = computed(() => {
     const schemaVariant = schemaVariantList.value[selectedVariantIndex.value]
-    return schemaVariant ?? schemaModel.value
+    return schemaVariant ?? resolvedSchemaObject.value
   })
 
+  // the raw (pre-resolve) selected variant - the identity checked for cycles, and what a
+  // recursive render should pass down as its own schema
+  const rawSelectedVariant = computed<SchemaObject | undefined>(() => rawVariantList.value[selectedVariantIndex.value])
+
+  // ancestors plus this schema's own identity, registered immediately so a variant cycling
+  // straight back to this node (not just a more distant ancestor) is caught with no extra hop
+  const ancestorsIncludingSelf = computed(() => {
+    const next = new Set(unref(ancestorSchemas))
+    next.add(unref(rawSchema))
+    return next
+  })
+
+  const isCircularVariant = computed(() =>
+    Boolean(rawSelectedVariant.value) && ancestorsIncludingSelf.value.has(rawSelectedVariant.value as object),
+  )
+
   return {
+    resolvedSchemaObject,
     inheritanceTypeLabel,
     variantSelectItemList,
     selectedVariantIndex,
     selectedSchemaModel,
+    rawSelectedVariant,
+    isCircularVariant,
+    ancestorsIncludingSelf,
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -142,7 +142,7 @@ export const DISABLE_SCROLLING_ITEMS_LIMIT = 1200
 
 export const DEFAULT_EXPANDED_PROPERTIES_DEPTH = 1
 
-// oneOf/anyOf variants render eagerly (unlike nested properties, which require a manual
-// "Show Child Parameters" click), so a schema whose variants cycle back to an ancestor needs
-// its own recursion cap to avoid mounting components forever
-export const MAX_VARIANT_RECURSION_DEPTH = 10
+// Backstop for oneOf/anyOf variant recursion (see useSchemaVariants' ancestor-chain guard,
+// the primary defense). Variants render eagerly, unlike nested properties, so a circular
+// schema needs a guard against mounting forever; this only kicks in if that guard is defeated.
+export const MAX_VARIANT_RECURSION_DEPTH = 50

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -141,3 +141,8 @@ export const MIN_SCROLL_DIFFERENCE = 20
 export const DISABLE_SCROLLING_ITEMS_LIMIT = 1200
 
 export const DEFAULT_EXPANDED_PROPERTIES_DEPTH = 1
+
+// oneOf/anyOf variants render eagerly (unlike nested properties, which require a manual
+// "Show Child Parameters" click), so a schema whose variants cycle back to an ancestor needs
+// its own recursion cap to avoid mounting components forever
+export const MAX_VARIANT_RECURSION_DEPTH = 10

--- a/src/utils/schema-example.spec.ts
+++ b/src/utils/schema-example.spec.ts
@@ -211,6 +211,94 @@ describe('crawl', () => {
     })
   })
 
+  // crawl() is deterministic, so this can't observe a memo hit vs. a correct recompute through
+  // output alone - it's a correctness regression guard for the array-typed shared-reference
+  // shape, not proof of memoization. resolveSchemaObjectFields returns a freshly-copied object
+  // for array-typed schemas (to hoist the items' fields up), so memoizing under that resolved
+  // copy would never match a repeat visit - the same identity-breaking shape that also affected
+  // the sensitive-data-masking guard, fixed here via the memoKey option in doCrawl.
+  it('produces correct output for an array-typed schema shared by reference across sibling properties', () => {
+    const sharedArrayProp = {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+            example: 'shared-array-id',
+          },
+        },
+      },
+    }
+    const objData = {
+      type: 'object',
+      properties: {
+        first: sharedArrayProp,
+        second: sharedArrayProp,
+      },
+    }
+
+    const res = crawl({ objData, filteringOptions: { excludeReadonly: false, excludeNotRequired: false } })
+    expect(res).toEqual({
+      first: [{ id: 'shared-array-id' }],
+      second: [{ id: 'shared-array-id' }],
+    })
+  })
+
+  // MAX_NESTED_LEVELS truncation is depth-dependent, but the memo cache key was not - a schema
+  // shared by reference at two different nesting depths must still truncate independently at
+  // each depth, not have the first-computed occurrence's result reused verbatim at the other
+  it('truncates independently for a schema shared by reference at two different nesting depths', () => {
+    const shared = {
+      type: 'object',
+      properties: {
+        a1: {
+          type: 'object',
+          properties: {
+            a2: {
+              type: 'object',
+              properties: {
+                leaf: { type: 'string', example: 'leaf-value' },
+              },
+            },
+          },
+        },
+      },
+    }
+    const objData = {
+      type: 'object',
+      properties: {
+        // reached at nestedLevel 1 - shallow enough that the full 2-level chain inside `shared`
+        // fits under MAX_NESTED_LEVELS (6) and resolves in full
+        shallow: shared,
+        // reached at nestedLevel 4 (3 wrapper hops deep) - the same 2-level chain inside
+        // `shared` now crosses MAX_NESTED_LEVELS partway through, so it must truncate before
+        // reaching `leaf`
+        wrapper1: {
+          type: 'object',
+          properties: {
+            wrapper2: {
+              type: 'object',
+              properties: {
+                wrapper3: {
+                  type: 'object',
+                  properties: {
+                    deep: shared,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const res = crawl({ objData, filteringOptions: { excludeReadonly: false, excludeNotRequired: false } })
+
+    expect(JSON.stringify(res?.shallow)).toContain('leaf-value')
+    expect(JSON.stringify(res?.wrapper1.wrapper2.wrapper3.deep)).not.toContain('leaf-value')
+  })
+
   it('should handle array example', () => {
     const objData = {
       'type': 'object',

--- a/src/utils/schema-example.spec.ts
+++ b/src/utils/schema-example.spec.ts
@@ -184,6 +184,33 @@ describe('crawl', () => {
     expect(crawl({ objData, filteringOptions: { excludeReadonly: false, excludeNotRequired: false } })).toEqual({ age: 0, name: 'name', refToName: 0 })
   })
 
+  it('reuses the memoized sample for a schema shared by reference across sibling properties', () => {
+    // both properties point at the exact same schema object, as two sibling properties
+    // referencing the same $ref would after dereferencing
+    const shared = {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+          example: 'shared-id',
+        },
+      },
+    }
+    const objData = {
+      type: 'object',
+      properties: {
+        first: shared,
+        second: shared,
+      },
+    }
+
+    const res = crawl({ objData, filteringOptions: { excludeReadonly: false, excludeNotRequired: false } })
+    expect(res).toEqual({
+      first: { id: 'shared-id' },
+      second: { id: 'shared-id' },
+    })
+  })
+
   it('should handle array example', () => {
     const objData = {
       'type': 'object',

--- a/src/utils/schema-example.ts
+++ b/src/utils/schema-example.ts
@@ -112,7 +112,7 @@ export const crawl = ({ objData, parentKey = '', nestedLevel = 0, filteringOptio
     WeakMap we store child objData's sampleObjects in weakMap so that when
     we see it's already stored, instead of extracting sampleObject again and again, we use what already extracted and stored in the WeakMap
   */
-  const seen = new WeakMap()
+  const seen = new WeakMap<Record<string, any>, Record<string, any>>()
 
   /**
  * util to generate example for inherited fields like allOf, anyOf, oneOf
@@ -190,9 +190,9 @@ export const crawl = ({ objData, parentKey = '', nestedLevel = 0, filteringOptio
     /*
       here is where we do lookup into WeakMap, and we we already have record there, just return already parsed sample object
     */
-    const seenRecord = seen.get(objData)
-    if (seenRecord) {
-      return seenRecord.seenSample
+    const seenSample = seen.get(objData)
+    if (seenSample) {
+      return seenSample
     }
 
 
@@ -274,7 +274,7 @@ export const crawl = ({ objData, parentKey = '', nestedLevel = 0, filteringOptio
     /*
       now, as we have sampleObj for objData extracted, we store it in the WeakMap for future child objects to use
     */
-    seen.set(objData, { sampleObj, parentKey })
+    seen.set(objData, sampleObj)
     return sampleObj
   }
 

--- a/src/utils/schema-example.ts
+++ b/src/utils/schema-example.ts
@@ -96,6 +96,13 @@ interface CrawlOptions {
   parentKey?: string
   nestedLevel?: number
   filteringOptions: Record<string, boolean>
+  /**
+   * Identity to memoize this call's result under, if different from objData. Use the raw,
+   * pre-resolve property: resolveSchemaObjectFields copies array/allOf schemas on every call,
+   * so memoizing under its output would never hit on a repeat visit. Omit when objData is
+   * already raw (e.g. the top-level call, or an allOf member).
+   */
+  memoKey?: Record<string, any>
 }
 
 /**
@@ -109,10 +116,11 @@ interface CrawlOptions {
 export const crawl = ({ objData, parentKey = '', nestedLevel = 0, filteringOptions }: CrawlOptions): Record<string, any> | null => {
 
   /*
-    WeakMap we store child objData's sampleObjects in weakMap so that when
-    we see it's already stored, instead of extracting sampleObject again and again, we use what already extracted and stored in the WeakMap
+    Memoizes sampleObj by object identity so a schema reused by reference isn't re-extracted.
+    Keyed on nestedLevel too: MAX_NESTED_LEVELS truncation is depth-dependent, so a memo from
+    one depth must never be reused at a different depth for the same schema.
   */
-  const seen = new WeakMap<Record<string, any>, Record<string, any>>()
+  const seen = new WeakMap<Record<string, any>, Map<number, Record<string, any>>>()
 
   /**
  * util to generate example for inherited fields like allOf, anyOf, oneOf
@@ -162,7 +170,7 @@ export const crawl = ({ objData, parentKey = '', nestedLevel = 0, filteringOptio
    * @param {CrawlOptions} CrawlOptions
    * @returns {Record<string, any> | null}
   */
-  const doCrawl = ({ objData, parentKey = '', nestedLevel = 0, filteringOptions }: CrawlOptions): Record<string, any> | null => {
+  const doCrawl = ({ objData, parentKey = '', nestedLevel = 0, filteringOptions, memoKey }: CrawlOptions): Record<string, any> | null => {
 
     let sampleObj = <Record<string, any>>{}
 
@@ -190,7 +198,7 @@ export const crawl = ({ objData, parentKey = '', nestedLevel = 0, filteringOptio
     /*
       here is where we do lookup into WeakMap, and we we already have record there, just return already parsed sample object
     */
-    const seenSample = seen.get(objData)
+    const seenSample = seen.get(memoKey ?? objData)?.get(nestedLevel)
     if (seenSample) {
       return seenSample
     }
@@ -228,6 +236,7 @@ export const crawl = ({ objData, parentKey = '', nestedLevel = 0, filteringOptio
                 parentKey: key,
                 nestedLevel: nestedLevel + 1,
                 filteringOptions,
+                memoKey: objData.properties[key],
               })
               : crawlInheritedProperties({
                 objData: oData,
@@ -244,7 +253,7 @@ export const crawl = ({ objData, parentKey = '', nestedLevel = 0, filteringOptio
               : exampleArrayItem === '[]' ? [] : [exampleArrayItem]
           }
         } else if (oDataType === 'object' || oData.allOf) {
-          const res = doCrawl({ objData: oData || {}, parentKey: key, nestedLevel: nestedLevel + 1, filteringOptions })
+          const res = doCrawl({ objData: oData || {}, parentKey: key, nestedLevel: nestedLevel + 1, filteringOptions, memoKey: objData.properties[key] })
           if (res !== null) {
             sampleObj[key] = res
           }
@@ -274,7 +283,11 @@ export const crawl = ({ objData, parentKey = '', nestedLevel = 0, filteringOptio
     /*
       now, as we have sampleObj for objData extracted, we store it in the WeakMap for future child objects to use
     */
-    seen.set(objData, sampleObj)
+    const identity = memoKey ?? objData
+    if (!seen.has(identity)) {
+      seen.set(identity, new Map())
+    }
+    seen.get(identity)!.set(nestedLevel, sampleObj)
     return sampleObj
   }
 

--- a/src/utils/schema-model.spec.ts
+++ b/src/utils/schema-model.spec.ts
@@ -482,5 +482,217 @@ describe('removeReadonlyFields', () => {
       }
       expect(removeFieldsFromSchemaObject(schemaObject)).toEqual(expectedSchemaObject)
     })
+
+    it('from a self-referencing (circular) schema object without throwing', () => {
+      // a schema whose `items` property points back to the schema object itself, as happens
+      // when the parser dereferences a recursive OpenAPI `$ref` with `circular: true`
+      const properties: Record<string, SchemaObject> = {
+        id: {
+          type: 'string',
+        },
+        name: {
+          type: 'string',
+          readOnly: true,
+        },
+      }
+      const schemaObject: SchemaObject = {
+        type: 'object',
+        properties,
+        required: ['id'],
+      }
+      // create a genuine circular reference: schemaObject.properties.children.items === schemaObject
+      properties.children = {
+        type: 'array',
+        items: schemaObject,
+      }
+
+      let result: SchemaObject | undefined
+      expect(() => {
+        result = removeFieldsFromSchemaObject(schemaObject)
+      }).not.toThrow()
+
+      // readOnly fields are still removed from the reachable, non-circular part of the schema
+      expect(result?.properties?.id).toEqual({ type: 'string' })
+      expect(result?.properties?.name).toBeUndefined()
+      // the circular branch is preserved without infinitely re-expanding
+      expect(result?.properties?.children).toBeDefined()
+      // readOnly fields are still stripped from the schema object returned at the cycle boundary
+      // itself (schemaObject.properties.children.items resolves back to schemaObject) - the
+      // filter must not leak through just because further recursion stops there
+      const children = result?.properties?.children as SchemaObject | undefined
+      const cyclePoint = children?.items as SchemaObject | undefined
+      expect(cyclePoint?.properties?.id).toEqual({ type: 'string' })
+      expect(cyclePoint?.properties?.name).toBeUndefined()
+    })
+
+    it('continues stripping readOnly fields around every lap of a cycle, without ever handing back a live reference to the original input', () => {
+      // regression test: an earlier version of this fix only shallow-filtered the object
+      // returned at the cycle boundary, so following the cycle one hop further than that
+      // (schemaObject -> children.items -> children.items again) landed back on the raw,
+      // un-filtered, mutable original schemaObject - re-exposing readOnly fields and letting
+      // callers mutate the caller's original spec document through the "filtered" result
+      const properties: Record<string, SchemaObject> = {
+        id: { type: 'string' },
+        name: { type: 'string', readOnly: true },
+      }
+      const schemaObject: SchemaObject = { type: 'object', properties, required: ['id'] }
+      properties.children = { type: 'array', items: schemaObject }
+
+      const result = removeFieldsFromSchemaObject(schemaObject)
+      const resultChildren = result.properties?.children as SchemaObject | undefined
+      const oneHop = resultChildren?.items as SchemaObject | undefined
+      const oneHopChildren = oneHop?.properties?.children as SchemaObject | undefined
+      const twoHops = oneHopChildren?.items as SchemaObject | undefined
+
+      expect(twoHops?.properties?.name).toBeUndefined()
+      expect(twoHops).not.toBe(schemaObject)
+    })
+
+    it('from a schema object that directly references itself via a property (not through items)', () => {
+      // schemaObject.properties.self === schemaObject, a cycle reached without going through
+      // an array `items` boundary at all
+      const properties: Record<string, SchemaObject> = {
+        id: { type: 'string' },
+        name: { type: 'string', readOnly: true },
+      }
+      const schemaObject: SchemaObject = {
+        type: 'object',
+        properties,
+        required: ['id'],
+      }
+      properties.self = schemaObject
+
+      let result: SchemaObject | undefined
+      expect(() => {
+        result = removeFieldsFromSchemaObject(schemaObject)
+      }).not.toThrow()
+
+      expect(result?.properties?.id).toEqual({ type: 'string' })
+      expect(result?.properties?.name).toBeUndefined()
+      expect(result?.properties?.self).toBeDefined()
+      // readOnly fields are also stripped from the object returned at the cycle boundary itself
+      const cyclePoint = result?.properties?.self as SchemaObject | undefined
+      expect(cyclePoint?.properties?.id).toEqual({ type: 'string' })
+      expect(cyclePoint?.properties?.name).toBeUndefined()
+    })
+
+    it('from a schema object with a circular reference inside oneOf', () => {
+      // the oneOf branch's own properties eventually cycle back to the top-level object
+      const parentSchema: SchemaObject = { type: 'object', properties: {}, oneOf: [] }
+      const oneOfProperties: Record<string, SchemaObject> = {
+        name: { type: 'string', readOnly: true },
+        age: { type: 'number' },
+        parent: parentSchema,
+      }
+      parentSchema.oneOf = [{ type: 'object', properties: oneOfProperties }]
+
+      let result: SchemaObject | undefined
+      expect(() => {
+        result = removeFieldsFromSchemaObject(parentSchema)
+      }).not.toThrow()
+
+      const resultOneOf = result?.oneOf?.[0] as SchemaObject
+      expect(resultOneOf.properties?.age).toEqual({ type: 'number' })
+      expect(resultOneOf.properties?.name).toBeUndefined()
+      expect(resultOneOf.properties?.parent).toBeDefined()
+    })
+
+    it('from a schema object with a circular reference inside anyOf', () => {
+      const parentSchema: SchemaObject = { type: 'object', properties: {}, anyOf: [] }
+      const anyOfProperties: Record<string, SchemaObject> = {
+        name: { type: 'string', readOnly: true },
+        age: { type: 'number' },
+        parent: parentSchema,
+      }
+      parentSchema.anyOf = [{ type: 'object', properties: anyOfProperties }]
+
+      let result: SchemaObject | undefined
+      expect(() => {
+        result = removeFieldsFromSchemaObject(parentSchema)
+      }).not.toThrow()
+
+      const resultAnyOf = result?.anyOf?.[0] as SchemaObject
+      expect(resultAnyOf.properties?.age).toEqual({ type: 'number' })
+      expect(resultAnyOf.properties?.name).toBeUndefined()
+      expect(resultAnyOf.properties?.parent).toBeDefined()
+    })
+
+    it('filters readOnly fields nested under an array-typed oneOf/anyOf branch, not just the branch\'s own properties', () => {
+      // regression test: oneOf/anyOf branches only ever had their own `.properties` filtered
+      // (via filterSchemaProperties), then were spread back in raw - so a branch that was itself
+      // an array (`items`) or contained a further nested oneOf/anyOf was copied through
+      // completely unfiltered, by live reference to the original input. This is the same class
+      // of leak fixed elsewhere for properties/items, just left open for oneOf/anyOf branches.
+      const schemaWithOneOf: SchemaObject = {
+        oneOf: [
+          {
+            type: 'array',
+            items: { type: 'object', properties: { secret: { type: 'string', readOnly: true } } },
+          },
+        ],
+      }
+      const resultOneOf = removeFieldsFromSchemaObject(schemaWithOneOf)
+      const oneOfItems = resultOneOf.oneOf?.[0] as SchemaObject | undefined
+      const oneOfItemsSchema = oneOfItems?.items as SchemaObject | undefined
+      expect(oneOfItemsSchema?.properties?.secret).toBeUndefined()
+      expect(oneOfItemsSchema).not.toBe((schemaWithOneOf.oneOf?.[0] as SchemaObject).items)
+
+      const schemaWithAnyOf: SchemaObject = {
+        anyOf: [
+          {
+            type: 'array',
+            items: { type: 'object', properties: { secret: { type: 'string', readOnly: true } } },
+          },
+        ],
+      }
+      const resultAnyOf = removeFieldsFromSchemaObject(schemaWithAnyOf)
+      const anyOfItems = resultAnyOf.anyOf?.[0] as SchemaObject | undefined
+      const anyOfItemsSchema = anyOfItems?.items as SchemaObject | undefined
+      expect(anyOfItemsSchema?.properties?.secret).toBeUndefined()
+      expect(anyOfItemsSchema).not.toBe((schemaWithAnyOf.anyOf?.[0] as SchemaObject).items)
+    })
+
+    it('filters readOnly independently from a schema shared (non-circularly) by sibling properties', () => {
+      // two properties pointing at the *same* reusable component schema object is a common,
+      // legitimate pattern in dereferenced OpenAPI documents - it must not be mistaken for a
+      // cycle and skipped on its second occurrence
+      const shared: SchemaObject = {
+        type: 'object',
+        properties: {
+          secret: { type: 'string', readOnly: true },
+          visible: { type: 'string' },
+        },
+      }
+      const schemaObject: SchemaObject = {
+        type: 'object',
+        properties: {
+          a: shared,
+          b: shared,
+        },
+      }
+
+      const result = removeFieldsFromSchemaObject(schemaObject)
+
+      expect(result.properties?.a).toEqual({ type: 'object', properties: { visible: { type: 'string' } } })
+      expect(result.properties?.b).toEqual({ type: 'object', properties: { visible: { type: 'string' } } })
+    })
+
+    it('from a very deeply nested (non-circular) schema chain without stack-overflowing', () => {
+      // added because the live production crash this fix targets surfaced as
+      // "RangeError: Maximum call stack size exceeded", not the simpler circular-JSON TypeError
+      // covered above - the `seen` cycle guard alone doesn't prevent that, since a single
+      // JSON.stringify call still walks the *entire* remaining subtree natively in one shot;
+      // this asserts the last-resort catch handles pure nesting depth too
+      const DEPTH = 5000
+      const root: SchemaObject = { type: 'object', properties: {} }
+      let current = root
+      for (let i = 0; i < DEPTH; i++) {
+        const next: SchemaObject = { type: 'object', properties: {} }
+        current.properties!.child = next
+        current = next
+      }
+
+      expect(() => removeFieldsFromSchemaObject(root)).not.toThrow()
+    })
   })
 })

--- a/src/utils/schema-model.spec.ts
+++ b/src/utils/schema-model.spec.ts
@@ -695,4 +695,88 @@ describe('removeReadonlyFields', () => {
       expect(() => removeFieldsFromSchemaObject(root)).not.toThrow()
     })
   })
+
+  describe('error handling in filtering steps', () => {
+    // each step's try/catch is meant to tolerate stack depth (RangeError) only - anything else
+    // is a real bug in filterMethod (or a future regression) and must surface, not vanish into
+    // a silently unfiltered field
+    const throwingFilterMethod = (property: SchemaObject): boolean => {
+      if (property.title === 'boom') throw new Error('unexpected filter error')
+      return Boolean(property.readOnly)
+    }
+
+    it('propagates a non-RangeError thrown while filtering properties', () => {
+      const schemaObject: SchemaObject = {
+        type: 'object',
+        properties: { bad: { type: 'string', title: 'boom' } },
+      }
+      expect(() => removeFieldsFromSchemaObject(schemaObject, throwingFilterMethod)).toThrow('unexpected filter error')
+    })
+
+    it('propagates a non-RangeError thrown while filtering items', () => {
+      const schemaObject: SchemaObject = {
+        type: 'array',
+        items: { type: 'object', properties: { bad: { type: 'string', title: 'boom' } } },
+      }
+      expect(() => removeFieldsFromSchemaObject(schemaObject, throwingFilterMethod)).toThrow('unexpected filter error')
+    })
+
+    it('propagates a non-RangeError thrown while filtering oneOf', () => {
+      const schemaObject: SchemaObject = {
+        oneOf: [{ type: 'object', title: 'boom' }],
+      }
+      expect(() => removeFieldsFromSchemaObject(schemaObject, throwingFilterMethod)).toThrow('unexpected filter error')
+    })
+
+    it('propagates a non-RangeError thrown while filtering anyOf', () => {
+      const schemaObject: SchemaObject = {
+        anyOf: [{ type: 'object', title: 'boom' }],
+      }
+      expect(() => removeFieldsFromSchemaObject(schemaObject, throwingFilterMethod)).toThrow('unexpected filter error')
+    })
+
+    // a real 5000-level-deep schema is not a valid way to test this: JSON.stringify serializes
+    // the whole graph regardless of recursion depth, so it always overflows on the outermost
+    // call, before recursion ever reaches these four steps. Throwing RangeError directly from
+    // filterMethod exercises each step's own catch instead.
+    const rangeErrorFilterMethod = (): boolean => {
+      throw new RangeError('simulated stack depth')
+    }
+
+    it('swallows a RangeError while filtering properties and keeps the clone', () => {
+      const schemaObject: SchemaObject = { type: 'object', properties: { child: { type: 'string' } } }
+      let result: SchemaObject | undefined
+      expect(() => {
+        result = removeFieldsFromSchemaObject(schemaObject, rangeErrorFilterMethod)
+      }).not.toThrow()
+      expect(result?.properties).toEqual(schemaObject.properties)
+    })
+
+    it('swallows a RangeError while filtering items and keeps the clone', () => {
+      const schemaObject: SchemaObject = { type: 'array', items: { type: 'object', properties: { child: { type: 'string' } } } }
+      let result: SchemaObject | undefined
+      expect(() => {
+        result = removeFieldsFromSchemaObject(schemaObject, rangeErrorFilterMethod)
+      }).not.toThrow()
+      expect(result?.items).toEqual(schemaObject.items)
+    })
+
+    it('swallows a RangeError while filtering oneOf and keeps the clone', () => {
+      const schemaObject: SchemaObject = { oneOf: [{ type: 'object', title: 'A' }] }
+      let result: SchemaObject | undefined
+      expect(() => {
+        result = removeFieldsFromSchemaObject(schemaObject, rangeErrorFilterMethod)
+      }).not.toThrow()
+      expect(result?.oneOf).toEqual(schemaObject.oneOf)
+    })
+
+    it('swallows a RangeError while filtering anyOf and keeps the clone', () => {
+      const schemaObject: SchemaObject = { anyOf: [{ type: 'object', title: 'A' }] }
+      let result: SchemaObject | undefined
+      expect(() => {
+        result = removeFieldsFromSchemaObject(schemaObject, rangeErrorFilterMethod)
+      }).not.toThrow()
+      expect(result?.anyOf).toEqual(schemaObject.anyOf)
+    })
+  })
 })

--- a/src/utils/schema-model.ts
+++ b/src/utils/schema-model.ts
@@ -265,7 +265,7 @@ export function removeFieldsFromSchemaObject(schemaObject: SchemaObject, filterM
     try {
       const newOneOfList: SchemaObject['oneOf'] = []
       schemaObject.oneOf.forEach((item) => {
-        // if the item is not a valid schema object or it fails the condiiton in filterMethod, we skip it
+        // if the item is not a valid schema object or it fails the condition in filterMethod, we skip it
         if (!isValidSchemaObject(item) || filterMethod(item)) return
 
         // recurse through the same cycle-safe walk used for properties/items, so an array-typed

--- a/src/utils/schema-model.ts
+++ b/src/utils/schema-model.ts
@@ -245,7 +245,10 @@ export function removeFieldsFromSchemaObject(schemaObject: SchemaObject, filterM
   if (schemaObject.properties) {
     try {
       newObj.properties = filterSchemaProperties(schemaObject.properties, filterMethod, seen)
-    } catch {
+    } catch (err) {
+      // only stack depth is expected here; anything else is a real bug and should surface, not
+      // vanish into an unfiltered field
+      if (!(err instanceof RangeError)) throw err
       // leave whatever `properties` the initial clone produced
     }
   }
@@ -253,7 +256,8 @@ export function removeFieldsFromSchemaObject(schemaObject: SchemaObject, filterM
     try {
       // items itself is a valid schema object, so we need to filter its properties, oneOf and anyOf
       newObj.items = removeFieldsFromSchemaObject(schemaObject.items, filterMethod, seen)
-    } catch {
+    } catch (err) {
+      if (!(err instanceof RangeError)) throw err
       // leave whatever `items` the initial clone produced
     }
   }
@@ -270,7 +274,8 @@ export function removeFieldsFromSchemaObject(schemaObject: SchemaObject, filterM
         newOneOfList.push(removeFieldsFromSchemaObject(item, filterMethod, seen))
       })
       newObj.oneOf = newOneOfList
-    } catch {
+    } catch (err) {
+      if (!(err instanceof RangeError)) throw err
       // leave whatever `oneOf` the initial clone produced
     }
   }
@@ -282,7 +287,8 @@ export function removeFieldsFromSchemaObject(schemaObject: SchemaObject, filterM
         newAnyOfList.push(removeFieldsFromSchemaObject(item, filterMethod, seen))
       })
       newObj.anyOf = newAnyOfList
-    } catch {
+    } catch (err) {
+      if (!(err instanceof RangeError)) throw err
       // leave whatever `anyOf` the initial clone produced
     }
   }

--- a/src/utils/schema-model.ts
+++ b/src/utils/schema-model.ts
@@ -150,10 +150,15 @@ type SchemaPropertyFilterMethod = (property: SchemaObject) => boolean
 
 /**
  * Utility to filter out fields from a properties object based on the conditions in filterMethod
+ *
+ * @param seen Memoizes the filtered result per schema object, keyed by the original object's
+ * identity. Revisiting the same object (a circular `$ref`, or a schema shared non-circularly by
+ * sibling properties) returns the already-filtered result instead of recursing again.
  */
 function filterSchemaProperties(
   propertiesObject: SchemaObject['properties'],
   filterMethod: SchemaPropertyFilterMethod,
+  seen: WeakMap<object, SchemaObject>,
 ): NonNullable<SchemaObject['properties']> {
   if (!propertiesObject) return {}
 
@@ -176,7 +181,7 @@ function filterSchemaProperties(
      * - properties under oneOf/anyOf, if present
      * which is done by calling removeFieldsFromSchemaObject
      */
-    filteredObj[key] = removeFieldsFromSchemaObject(currentItem, filterMethod)
+    filteredObj[key] = removeFieldsFromSchemaObject(currentItem, filterMethod, seen)
   })
 
   return filteredObj
@@ -190,39 +195,101 @@ function filterSchemaProperties(
  * - properties of current object
  * - items object
  * - oneOf/anyOf
+ *
+ * @param seen Internal only: memoizes the filtered result per schema object, keyed by identity
+ * (see `filterSchemaProperties` above). Without this, a circular `$ref` (the parser preserves
+ * these as live circular object references via `dereference: { circular: true }`) recurses
+ * forever, throwing "Converting circular structure to JSON" or "Maximum call stack size
+ * exceeded" and crashing the whole document render.
+ *
+ * The result is registered in `seen` before recursing into its own properties/items/oneOf/anyOf,
+ * so a cycle back to this object resolves to that same (by-then fully populated) result instead
+ * of a raw copy of the original. `seen` is never cleared, so a schema reached via more than one
+ * non-circular path is also filtered once and shared across occurrences.
+ *
+ * `seen` only guards against revisiting an object; it does not bound sheer nesting depth. A
+ * schema nested deep enough, even without a cycle, can still overflow the stack, since both
+ * `JSON.stringify` and its `removeCircularRefs` fallback walk the whole remaining subtree in one
+ * call. Each step below (the initial clone, and the properties/items/oneOf/anyOf recursion) has
+ * its own `try`/`catch` so a stack overflow (or any other error) only degrades that one step,
+ * keeping the rest of this node's already-filtered fields intact instead of discarding the whole
+ * node or document.
  */
-export function removeFieldsFromSchemaObject(schemaObject: SchemaObject, filterMethod: SchemaPropertyFilterMethod = removeReadonlyFields): SchemaObject {
-  const newObj: SchemaObject = JSON.parse(JSON.stringify(schemaObject))
+export function removeFieldsFromSchemaObject(schemaObject: SchemaObject, filterMethod: SchemaPropertyFilterMethod = removeReadonlyFields, seen: WeakMap<object, SchemaObject> = new WeakMap()): SchemaObject {
+  const cached = seen.get(schemaObject)
+  if (cached) return cached
+
+  let newObj: SchemaObject
+  // a RangeError means we've hit real stack depth (not just a circular reference, which throws
+  // TypeError). Recursing further would just repeat the same overflow at every remaining level,
+  // so give up on this whole subtree right away instead of retrying node by node.
+  let stackOverflowed = false
+  try {
+    newObj = JSON.parse(JSON.stringify(schemaObject))
+  } catch (err) {
+    if (err instanceof RangeError) {
+      newObj = { ...schemaObject }
+      stackOverflowed = true
+    } else {
+      try {
+        // schemaObject contains a circular reference; fall back to a circular-safe clone
+        newObj = removeCircularRefs(schemaObject)
+      } catch (err2) {
+        newObj = { ...schemaObject }
+        stackOverflowed = err2 instanceof RangeError
+      }
+    }
+  }
+
+  seen.set(schemaObject, newObj)
+
+  if (stackOverflowed) {
+    return newObj
+  }
 
   if (schemaObject.properties) {
-    const filteredProperties = filterSchemaProperties(schemaObject.properties, filterMethod)
-    newObj.properties = filteredProperties
+    try {
+      newObj.properties = filterSchemaProperties(schemaObject.properties, filterMethod, seen)
+    } catch {
+      // leave whatever `properties` the initial clone produced
+    }
   }
   if (isValidSchemaObject(schemaObject.items)) {
-    // items itself is a valid schema object, so we need to filter its properties, oneOf and anyOf
-    const filteredItemsObject = removeFieldsFromSchemaObject(schemaObject.items, filterMethod)
-    newObj.items = filteredItemsObject
+    try {
+      // items itself is a valid schema object, so we need to filter its properties, oneOf and anyOf
+      newObj.items = removeFieldsFromSchemaObject(schemaObject.items, filterMethod, seen)
+    } catch {
+      // leave whatever `items` the initial clone produced
+    }
   }
   if (schemaObject.oneOf?.length) {
-    const newOneOfList: SchemaObject['oneOf'] = []
-    schemaObject.oneOf.forEach((item) => {
-      // if the item is not a valid schema object or it fails the condiiton in filterMethod, we skip it
-      if (!isValidSchemaObject(item) || filterMethod(item)) return
+    try {
+      const newOneOfList: SchemaObject['oneOf'] = []
+      schemaObject.oneOf.forEach((item) => {
+        // if the item is not a valid schema object or it fails the condiiton in filterMethod, we skip it
+        if (!isValidSchemaObject(item) || filterMethod(item)) return
 
-      // if the item is valid, we remove the fields from its properties
-      const filteredProperties = filterSchemaProperties(item.properties, filterMethod)
-      newOneOfList.push({ ...item, properties: filteredProperties })
-    })
-    newObj.oneOf = newOneOfList
+        // recurse through the same cycle-safe walk used for properties/items, so an array-typed
+        // (or otherwise nested) oneOf branch is filtered and cycle-guarded too, not just its
+        // top-level properties
+        newOneOfList.push(removeFieldsFromSchemaObject(item, filterMethod, seen))
+      })
+      newObj.oneOf = newOneOfList
+    } catch {
+      // leave whatever `oneOf` the initial clone produced
+    }
   }
   if (schemaObject.anyOf?.length) {
-    const newAnyOfList: SchemaObject['anyOf'] = []
-    schemaObject.anyOf.forEach((item) => {
-      if (!isValidSchemaObject(item) || filterMethod(item)) return
-      const filteredProperties = filterSchemaProperties(item.properties, filterMethod)
-      newAnyOfList.push({ ...item, properties: filteredProperties })
-    })
-    newObj.anyOf = newAnyOfList
+    try {
+      const newAnyOfList: SchemaObject['anyOf'] = []
+      schemaObject.anyOf.forEach((item) => {
+        if (!isValidSchemaObject(item) || filterMethod(item)) return
+        newAnyOfList.push(removeFieldsFromSchemaObject(item, filterMethod, seen))
+      })
+      newObj.anyOf = newAnyOfList
+    } catch {
+      // leave whatever `anyOf` the initial clone produced
+    }
   }
 
   return newObj

--- a/src/utils/schema-model.ts
+++ b/src/utils/schema-model.ts
@@ -196,24 +196,19 @@ function filterSchemaProperties(
  * - items object
  * - oneOf/anyOf
  *
- * @param seen Internal only: memoizes the filtered result per schema object, keyed by identity
- * (see `filterSchemaProperties` above). Without this, a circular `$ref` (the parser preserves
- * these as live circular object references via `dereference: { circular: true }`) recurses
- * forever, throwing "Converting circular structure to JSON" or "Maximum call stack size
- * exceeded" and crashing the whole document render.
+ * @param schemaObject The schema object to filter
+ * @param filterMethod Decides whether a given property should be removed
+ * @param seen Internal only: memoizes the filtered result per schema object, keyed by identity.
+ * A circular `$ref` (preserved as a live circular object reference via
+ * `dereference: { circular: true }`) would otherwise recurse forever and crash the render, so the
+ * result is registered before recursing into its own properties/items/oneOf/anyOf, letting a
+ * cycle resolve to that same object instead of an unfiltered copy. It also means a schema reached
+ * via more than one non-circular path is filtered once and shared, not reprocessed.
  *
- * The result is registered in `seen` before recursing into its own properties/items/oneOf/anyOf,
- * so a cycle back to this object resolves to that same (by-then fully populated) result instead
- * of a raw copy of the original. `seen` is never cleared, so a schema reached via more than one
- * non-circular path is also filtered once and shared across occurrences.
- *
- * `seen` only guards against revisiting an object; it does not bound sheer nesting depth. A
- * schema nested deep enough, even without a cycle, can still overflow the stack, since both
- * `JSON.stringify` and its `removeCircularRefs` fallback walk the whole remaining subtree in one
- * call. Each step below (the initial clone, and the properties/items/oneOf/anyOf recursion) has
- * its own `try`/`catch` so a stack overflow (or any other error) only degrades that one step,
- * keeping the rest of this node's already-filtered fields intact instead of discarding the whole
- * node or document.
+ * `seen` only guards against revisiting an object, not sheer nesting depth, since a single
+ * `JSON.stringify` call (and its `removeCircularRefs` fallback) can still overflow the stack on a
+ * very deeply nested schema. Each step below has its own `try`/`catch` so that failure only
+ * degrades that one step, not the whole node or document.
  */
 export function removeFieldsFromSchemaObject(schemaObject: SchemaObject, filterMethod: SchemaPropertyFilterMethod = removeReadonlyFields, seen: WeakMap<object, SchemaObject> = new WeakMap()): SchemaObject {
   const cached = seen.get(schemaObject)

--- a/src/utils/sensitive-data-masking.spec.ts
+++ b/src/utils/sensitive-data-masking.spec.ts
@@ -277,6 +277,49 @@ describe('hasMasking', () => {
   it('returns false for undefined schema and empty rules', () => {
     expect(hasMasking(undefined, [])).toBe(false)
   })
+
+  // a schema whose properties cycle back to an ancestor (a live circular object reference,
+  // as produced by dereferencing a circular $ref) must not recurse forever
+  it('does not recurse forever when the schema is circular and has no sensitive data', () => {
+    const schemaA: Record<string, any> = { properties: { name: { type: 'string' } } }
+    const schemaB: Record<string, any> = { properties: { parent: schemaA } }
+    schemaA.properties.child = schemaB
+
+    expect(() => hasMasking(schemaA, [])).not.toThrow()
+    expect(hasMasking(schemaA, [])).toBe(false)
+  })
+
+  // resolveSchemaObjectFields returns a freshly-copied object for array-typed schemas (to hoist
+  // the items' fields up), so a naive guard keyed on the resolved object would never match on
+  // repeat visits. This is the shape of the real production bug: a "children" array property
+  // whose items $ref back to the same schema.
+  it('does not recurse forever when the cycle passes through an array-typed property', () => {
+    const schemaA: Record<string, any> = {
+      properties: {
+        name: { type: 'string' },
+        children: {
+          type: 'array',
+          items: {},
+        },
+      },
+    }
+    schemaA.properties.children.items = schemaA
+
+    expect(() => hasMasking(schemaA, [])).not.toThrow()
+    expect(hasMasking(schemaA, [])).toBe(false)
+  })
+
+  it('still finds sensitive data reachable before a circular reference is hit', () => {
+    const schemaA: Record<string, any> = {
+      properties: {
+        password: { type: 'string', 'x-sensitive-data': { mask: 'full' } as XSensitiveData },
+      },
+    }
+    const schemaB: Record<string, any> = { properties: { parent: schemaA } }
+    schemaA.properties.child = schemaB
+
+    expect(hasMasking(schemaA, [])).toBe(true)
+  })
 })
 
 describe('findResponseSchema', () => {

--- a/src/utils/sensitive-data-masking.ts
+++ b/src/utils/sensitive-data-masking.ts
@@ -1,6 +1,6 @@
 import type { HttpSecurityScheme, IHttpOperationResponse } from '@stoplight/types'
 import type { XSensitiveData, SecuritySchemeMaskRule } from '@/types'
-import { resolveSchemaObjectFields } from './schema-model'
+import { isValidSchemaObject, resolveSchemaObjectFields } from './schema-model'
 import { OAS_EXT_SENSITIVE_DATA } from '@/oas-extensions'
 
 // ─── Mask placeholder ─────────────────────────────────────────────────────────
@@ -278,13 +278,23 @@ export const maskBodyExample = (example: unknown, schema: Record<string, any>): 
 /**
  * Return true if any property in the schema (recursively) has an x-sensitive-data annotation.
  * Used internally by hasMasking — prefer calling hasMasking directly.
+ *
+ * `seen` guards against a circular `$ref` (preserved as a live circular object reference)
+ * recursing forever. It tracks each property's raw, pre-resolve object, not the result of
+ * resolveSchemaObjectFields: that helper returns a freshly-copied object for array-typed or
+ * allOf-bearing schemas, so tracking the resolved copy would give every visit a new identity
+ * and the guard would never match. A single visited-once set is safe here, unlike a filtering
+ * walk: this is a pure boolean predicate, so a schema's answer doesn't depend on which path
+ * reached it, and whichever branch finds sensitive data first already short-circuits the walk.
  */
-const _schemaHasSensitiveData = (schema: Record<string, any> | undefined): boolean => {
+const _schemaHasSensitiveData = (schema: Record<string, any> | undefined, seen: WeakSet<object> = new WeakSet()): boolean => {
   if (!schema) return false
   for (const propSchema of Object.values(schema.properties ?? {})) {
+    if (!isValidSchemaObject(propSchema) || seen.has(propSchema)) continue
+    seen.add(propSchema)
     const prop = resolveSchemaObjectFields(propSchema) as Record<string, any>
     if (prop?.[OAS_EXT_SENSITIVE_DATA]) return true
-    if (prop?.properties && _schemaHasSensitiveData(prop)) return true
+    if (prop?.properties && _schemaHasSensitiveData(prop, seen)) return true
   }
   return false
 }

--- a/src/utils/sensitive-data-masking.ts
+++ b/src/utils/sensitive-data-masking.ts
@@ -279,13 +279,11 @@ export const maskBodyExample = (example: unknown, schema: Record<string, any>): 
  * Return true if any property in the schema (recursively) has an x-sensitive-data annotation.
  * Used internally by hasMasking — prefer calling hasMasking directly.
  *
- * `seen` guards against a circular `$ref` (preserved as a live circular object reference)
- * recursing forever. It tracks each property's raw, pre-resolve object, not the result of
- * resolveSchemaObjectFields: that helper returns a freshly-copied object for array-typed or
- * allOf-bearing schemas, so tracking the resolved copy would give every visit a new identity
- * and the guard would never match. A single visited-once set is safe here, unlike a filtering
- * walk: this is a pure boolean predicate, so a schema's answer doesn't depend on which path
- * reached it, and whichever branch finds sensitive data first already short-circuits the walk.
+ * `seen` guards against a circular `$ref` recursing forever, keyed on each property's raw,
+ * pre-resolve object (resolveSchemaObjectFields copies array/allOf schemas on every call, so
+ * keying on its output would never match a repeat visit). A visited-once set is safe here since
+ * this is a pure boolean predicate: the answer for a schema doesn't depend on which path reached
+ * it, and finding sensitive data anywhere already short-circuits the walk.
  */
 const _schemaHasSensitiveData = (schema: Record<string, any> | undefined, seen: WeakSet<object> = new WeakSet()): boolean => {
   if (!schema) return false


### PR DESCRIPTION
# Summary

Large or circular OpenAPI schemas (a `$ref` that points back at itself, directly or through a chain) could crash or freeze the browser when rendering an operation page.

This issue can (before merge) be reproduced at the URL linked [in the JIRA ticket](https://konghq.atlassian.net/browse/TDX-8503) (not added here as it references a customer OAS example).

## Root causes

Four separate places walked schema objects recursively with no protection against cycles:

- `removeFieldsFromSchemaObject`, used to filter readOnly fields out of request bodies. Threw `TypeError: Converting circular structure to JSON` or `RangeError: Maximum call stack size exceeded`.
- `ModelNode`/`ModelProperty`'s rendering of `oneOf`/`anyOf` variants, which mount eagerly and would recurse forever on a circular variant, freezing the browser.
- `crawl`'s sample-generation memoization, keyed incorrectly so shared schemas were never reused.
- `_schemaHasSensitiveData` (from #860), which recursed on schema properties with no bound at all. This was the actual cause of the production crash.

## Fixes

- `removeFieldsFromSchemaObject` now uses a `WeakMap` that memoizes each schema object's filtered result before recursing into its children. A cycle resolves to the same filtered object instead of recursing forever, and a schema reused by multiple properties is filtered once and shared. Each filtering step (properties, items, oneOf, anyOf) degrades independently on failure, so one bad branch doesn't discard already-filtered work elsewhere.
- `ModelNode`/`ModelProperty` variant rendering now uses an ancestor-chain identity check instead of a flat depth counter, so a circular schema stops at the exact repeat instead of duplicating content up to a cap. This logic is extracted into the `useSchemaVariants` composable (matching its existing pattern) so it's unit tested directly, not just through full component mounts.
- `crawl`'s memoization is fixed and now scoped by nesting depth, so shared schemas are reused correctly instead of reprocessed, skipped, or reused at the wrong depth.
- `_schemaHasSensitiveData` now has a cycle guard, closing the gap that caused the real crash from #860.

Together these stop the browser tab from freezing and the SSR render from crashing on specs with circular `$ref`s.

## Notes

- The `removeCircularRefs` util wasn't patched as it wasn't broken as-is -- it was already correct. It didn't need a fix because it's not a recursive walk. The bugs fixed were unguarded recursive functions. removeCircularRefs has no recursion. There's no loop for a missing cycle-guard to leave exposed.

## Testing

- See preview in portal here: https://github.com/kong-konnect/portal/pull/2640

## Notes

We'll want to prompt our `developer.konghq.com` team to pull in the updated package once merged.