### PR TITLE
fix(cli): rename and reorder fields

### DIFF
--- a/cli/commands/preview.ts
+++ b/cli/commands/preview.ts
@@ -43,9 +43,9 @@ export async function runPreviewCommand(specArg: string, flags: PreviewCommandFl
   const specLinkTarget = source.watchPath ? pathToFileURL(source.watchPath).href : specArg
 
   printPreviewBanner([
+    { label: 'Preview URL', value: pc.bold(pc.underline(hyperlink(url, url))) },
     { label: 'Spec', value: pc.bold(pc.underline(hyperlink(specArg, specLinkTarget))) },
-    { label: 'URL', value: pc.bold(pc.underline(hyperlink(url, url))) },
-    { label: 'Reload', value: isWatching ? pc.green('watching for changes') : pc.yellow('not available (remote URL)') },
+    { label: 'Live Reload', value: isWatching ? pc.green('watching for changes') : pc.yellow('not available (remote URL)') },
   ])
   console.log()
   info('Press Ctrl+C to stop')


### PR DESCRIPTION
# Summary

Reorder and rename the display fields in the CLI

<img width="419" height="123" alt="image" src="https://github.com/user-attachments/assets/5aa69635-a07b-475a-a34f-4a5f1a6ba7bb" />
