### PR TITLE
fix: query param description, allOf example[TDX-8636]

### DIFF
--- a/src/components/spec-document/endpoint/RequestParamList.spec.ts
+++ b/src/components/spec-document/endpoint/RequestParamList.spec.ts
@@ -86,4 +86,24 @@ describe('<RequestParamList />', () => {
 
     expect(paramWithStaleAllowList.findTestId('property-field-description').text()).toBe('The maximum number of results per page.')
   })
+
+  it('renders each param\'s own description when multiple params share the same schema object reference', () => {
+    // e.g. two params referencing the same components.parameters/components.schemas entry - the
+    // dereferenced schema object can be the exact same reference for both params
+    const sharedSchema: SchemaObject = { type: 'integer' }
+    const sharedSchemaParams = mount(RequestParamList, {
+      props: {
+        paramList: [
+          { name: 'paramA', id: 'paramA', style: HttpParamStyles.Form, description: 'Description A', schema: sharedSchema },
+          { name: 'paramB', id: 'paramB', style: HttpParamStyles.Form, description: 'Description B', schema: sharedSchema },
+        ],
+        title: 'sample-title',
+      },
+    })
+
+    expect(sharedSchemaParams.findTestId('model-property-param-a').find('[data-testid="property-field-description"]').text()).toBe('Description A')
+    expect(sharedSchemaParams.findTestId('model-property-param-b').find('[data-testid="property-field-description"]').text()).toBe('Description B')
+    // the shared schema object itself must not be mutated by rendering either param
+    expect(sharedSchema.description).toBeUndefined()
+  })
 })

--- a/src/components/spec-document/endpoint/RequestParamList.spec.ts
+++ b/src/components/spec-document/endpoint/RequestParamList.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
 import RequestParamList from './RequestParamList.vue'
 import { HttpParamStyles } from '@stoplight/types'
+import type { SchemaObject } from '@/types'
 
 describe('<RequestParamList />', () => {
   const wrapper = mount(RequestParamList, {
@@ -54,4 +55,35 @@ describe('<RequestParamList />', () => {
       expect(wrapper.findTestId(component).exists()).toBe(true)
     })
   }
+
+  it('renders the param description even when the schema carries a stale x-stoplight explicit-fields allow-list', () => {
+    // some stoplight http-spec transforms (e.g. numeric `format`s like int32) add `x-stoplight.explicitProperties`
+    // onto the schema before the param's own `description` gets merged in. that stale allow-list must not filter the description back out.
+    const limitSchema: SchemaObject = {
+      type: 'integer',
+      format: 'int32',
+      minimum: 1,
+      maximum: 100,
+      default: 20,
+      'x-stoplight': {
+        explicitProperties: ['type', 'format', 'minimum', 'maximum', 'default'],
+      },
+    }
+    const paramWithStaleAllowList = mount(RequestParamList, {
+      props: {
+        paramList: [
+          {
+            name: 'limit',
+            id: 'limit',
+            style: HttpParamStyles.Form,
+            description: 'The maximum number of results per page.',
+            schema: limitSchema,
+          },
+        ],
+        title: 'sample-title',
+      },
+    })
+
+    expect(paramWithStaleAllowList.findTestId('property-field-description').text()).toBe('The maximum number of results per page.')
+  })
 })

--- a/src/components/spec-document/endpoint/RequestParamList.vue
+++ b/src/components/spec-document/endpoint/RequestParamList.vue
@@ -42,7 +42,10 @@ defineProps({
 const populateParamProperty = (param: IHttpParam, schema: SchemaObject) => {
   if (!param.schema) return null
 
-  const property: SchemaObject = schema
+  // schema can be a reference shared by multiple params (e.g. via a shared $ref) - copy it
+  // rather than mutating it in place, or setting one param's description would leak onto every
+  // other param sharing the same schema object
+  const property: SchemaObject = { ...schema }
   if (param.description && !property?.description) {
     // sometimes description for path param is not present in the schema
     // and is instead added to the path param itself
@@ -54,7 +57,7 @@ const populateParamProperty = (param: IHttpParam, schema: SchemaObject) => {
     // 'description' to it too, or the description we just set gets filtered out of the render
     const explicitProperties = property[OAS_EXT_STOPLIGHT]?.explicitProperties
     if (Array.isArray(explicitProperties) && !explicitProperties.includes('description')) {
-      explicitProperties.push('description')
+      property[OAS_EXT_STOPLIGHT] = { ...property[OAS_EXT_STOPLIGHT], explicitProperties: [...explicitProperties, 'description'] }
     }
   }
 

--- a/src/components/spec-document/endpoint/RequestParamList.vue
+++ b/src/components/spec-document/endpoint/RequestParamList.vue
@@ -24,6 +24,7 @@ import type { PropType } from 'vue'
 import type { IHttpParam } from '@stoplight/types'
 import ModelProperty from '../schema-model/ModelProperty.vue'
 import CollapsibleSection from './CollapsibleSection.vue'
+import { OAS_EXT_STOPLIGHT } from '@/oas-extensions'
 import type { SchemaObject } from '@/types'
 
 defineProps({
@@ -46,6 +47,15 @@ const populateParamProperty = (param: IHttpParam, schema: SchemaObject) => {
     // sometimes description for path param is not present in the schema
     // and is instead added to the path param itself
     property.description = param.description
+
+    // x-stoplight.explicitProperties, when present, is an allow-list PropertyFieldList component uses to decide
+    // which fields to render. it's a snapshot of the schema's fields taken earlier by the stoplight
+    // transform (e.g. for formats like int32), before the description above was added. add
+    // 'description' to it too, or the description we just set gets filtered out of the render
+    const explicitProperties = property[OAS_EXT_STOPLIGHT]?.explicitProperties
+    if (Array.isArray(explicitProperties) && !explicitProperties.includes('description')) {
+      explicitProperties.push('description')
+    }
   }
 
   return property

--- a/src/utils/schema-model.spec.ts
+++ b/src/utils/schema-model.spec.ts
@@ -227,6 +227,35 @@ describe('resolveSchemaObjectFields', () => {
     }
     expect(resolveSchemaObjectFields(schemaObject)).toStrictEqual(expectedSchemaObject)
   })
+
+  it('lets a sibling `examples` override an allOf branch\'s `examples`, instead of concatenating both', () => {
+    // shape produced by @stoplight/http-spec, which converts `example` -> `examples: [value]`
+    // independently at every schema level (both the allOf branch and the containing schema)
+    const schemaObject: SchemaObject = {
+      allOf: [
+        { type: 'string', description: 'A generic string.', examples: ['foo'] },
+      ],
+      description: 'A specific, overriding description.',
+      examples: ['bar'],
+    }
+
+    const result = resolveSchemaObjectFields(schemaObject)
+    expect(result.examples).toStrictEqual(['bar'])
+    expect(result.example).toBeUndefined()
+  })
+
+  it('lets a sibling `example` override an allOf branch\'s `example`, instead of allof-merge\'s default behavior', () => {
+    const allOfItem: SchemaObject = { type: 'string', description: 'A generic string.', example: 'foo' }
+    const schemaObject: SchemaObject = {
+      allOf: [allOfItem],
+      description: 'A specific, overriding description.',
+      example: 'bar',
+    }
+
+    const result = resolveSchemaObjectFields(schemaObject)
+    expect(result.example).toBe('bar')
+    expect(result.examples).toBeUndefined()
+  })
 })
 
 describe('filterSchemaObjectArray', () => {

--- a/src/utils/schema-model.ts
+++ b/src/utils/schema-model.ts
@@ -37,24 +37,32 @@ const removeCircularRefs = (obj: Record<string, any>):Record<string, any> => {
 }
 
 /**
- * allof-merge concatenates the `examples` arrays contributed by an allOf branch and the containing
- * schema's own sibling `example`/`examples`, rather than letting the sibling override the branch's
- * value. attaching `example`/`description` alongside `allOf: [$ref]` is the standard OpenAPI
- * pattern for overriding a shared component's example for one specific usage site so if the schema itself declared its own example(s), that's
- * the authoritative value and should win outright, not be combined with the referenced schema's.
+ * Merges a schema's allOf sub-schemas via allof-merge, then makes the schema's own sibling
+ * `title`/`example`/`examples` win over the merge result.
+ *
+ * @param originalSchema the schema to merge; also read for the sibling overrides
+ * @param allOfForMerge the allOf array to merge, if different from originalSchema.allOf (e.g. a
+ * circular-reference-safe copy - see resolveAllOf)
  */
-const restoreSiblingExample = (originalSchema: SchemaObject, mergedSchema: SchemaObject): SchemaObject => {
+const mergeAllOf = (originalSchema: SchemaObject, allOfForMerge: SchemaObject['allOf'] = originalSchema.allOf): SchemaObject => {
+  const merged: SchemaObject = { ...(merge({ ...originalSchema, allOf: allOfForMerge }, { mergeCombinarySibling: true }) as SchemaObject) }
+
+  // restore title as allof-merge lets an allOf branch's title silently overwrite the sibling's
+  if (originalSchema.title) {
+    merged.title = originalSchema.title
+  }
+
+  // allof-merge concatenates example/examples across allOf branches instead of letting the sibling
+  // override - keep only the sibling's own value, clearing the other key so it can't win instead
   if (Object.hasOwn(originalSchema, 'examples')) {
-    const result = { ...mergedSchema, examples: originalSchema.examples }
-    delete result.example
-    return result
+    merged.examples = originalSchema.examples
+    delete merged.example
+  } else if (Object.hasOwn(originalSchema, 'example')) {
+    merged.example = originalSchema.example
+    delete merged.examples
   }
-  if (Object.hasOwn(originalSchema, 'example')) {
-    const result = { ...mergedSchema, example: originalSchema.example }
-    delete result.examples
-    return result
-  }
-  return mergedSchema
+
+  return merged
 }
 
 /**
@@ -86,17 +94,11 @@ const resolveAllOf = (schema: SchemaObject): SchemaObject => {
         delete result.anyOf
         return result
       })
-      return restoreSiblingExample(schema, {
-        ...(merge({ ...schema, allOf: cleanedAllOf }, { mergeCombinarySibling: true }) as SchemaObject),
-        ...(schema.title ? { title: schema.title } : {}),
-      })
+      return mergeAllOf(schema, cleanedAllOf)
     }
 
     // we are clean and do not have any circular refs - safe to use merge
-    return restoreSiblingExample(schema, {
-      ...(merge(schema, { mergeCombinarySibling: true }) as SchemaObject),
-      ...(schema.title ? { title: schema.title } : {}),
-    })
+    return mergeAllOf(schema)
   } else {
     return schema
   }

--- a/src/utils/schema-model.ts
+++ b/src/utils/schema-model.ts
@@ -37,6 +37,27 @@ const removeCircularRefs = (obj: Record<string, any>):Record<string, any> => {
 }
 
 /**
+ * allof-merge concatenates the `examples` arrays contributed by an allOf branch and the containing
+ * schema's own sibling `example`/`examples`, rather than letting the sibling override the branch's
+ * value. attaching `example`/`description` alongside `allOf: [$ref]` is the standard OpenAPI
+ * pattern for overriding a shared component's example for one specific usage site so if the schema itself declared its own example(s), that's
+ * the authoritative value and should win outright, not be combined with the referenced schema's.
+ */
+const restoreSiblingExample = (originalSchema: SchemaObject, mergedSchema: SchemaObject): SchemaObject => {
+  if (Object.hasOwn(originalSchema, 'examples')) {
+    const result = { ...mergedSchema, examples: originalSchema.examples }
+    delete result.example
+    return result
+  }
+  if (Object.hasOwn(originalSchema, 'example')) {
+    const result = { ...mergedSchema, example: originalSchema.example }
+    delete result.examples
+    return result
+  }
+  return mergedSchema
+}
+
+/**
  * Utility to resolve allOf fields in a schema object.
  *
  * If allOf is present, we merge the sub-schemas in allOf into the current schema object
@@ -65,17 +86,17 @@ const resolveAllOf = (schema: SchemaObject): SchemaObject => {
         delete result.anyOf
         return result
       })
-      return {
+      return restoreSiblingExample(schema, {
         ...(merge({ ...schema, allOf: cleanedAllOf }, { mergeCombinarySibling: true }) as SchemaObject),
         ...(schema.title ? { title: schema.title } : {}),
-      }
+      })
     }
 
     // we are clean and do not have any circular refs - safe to use merge
-    return {
+    return restoreSiblingExample(schema, {
       ...(merge(schema, { mergeCombinarySibling: true }) as SchemaObject),
       ...(schema.title ? { title: schema.title } : {}),
-    }
+    })
   } else {
     return schema
   }


### PR DESCRIPTION
# Summary

This PR aims to fix the following 2 bugs:-

1. query/path parameter descriptions with certain numeric formats (e.g. int32) were silently dropped. fixed by keeping the schema's stale `x-stoplight.explicitProperties` allow-list in sync when a parameter's description is merged onto it.
2. a sibling example on an allOf: [$ref] property was concatenated with (or lost to) the referenced schema's own example instead of overriding it. fixed by restoring the sibling's example/examples after allOf merging in `resolveAllOf`.

**Jira** - https://konghq.atlassian.net/browse/TDX-8636

**Preview**

https://github.com/user-attachments/assets/62a6381b-59f0-42d7-930e-88a4cdf1dca2




<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
