### PR TITLE
feat(slideout): mount slideout to spec-renderer container instead of body [TDX-6413]

### DIFF
--- a/sandbox/components/SampleSpecSelector.vue
+++ b/sandbox/components/SampleSpecSelector.vue
@@ -113,7 +113,7 @@ const optionsArrayOAS = [
   { url: 'https://raw.githubusercontent.com/stoplightio/Public-APIs/master/reference/netlify/openapi.yaml', label: 'Netlify' },
   { url: 'https://api.apis.guru/v2/specs/instagram.com/1.0.0/swagger.yaml', label: 'Instagram' },
   { url: 'https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json', label: 'Stripe' },
-  { url: 'https://httpbin.org/spec.json', label: 'Httpbin' },
+  { url: 'https://httpbin.konghq.com/spec.json', label: 'Httpbin' },
 ]
 
 

--- a/sandbox/pages/ComponentsPlayground.vue
+++ b/sandbox/pages/ComponentsPlayground.vue
@@ -1,24 +1,5 @@
 <template>
   <div class="wrapper">
-    <!--
-      Must stay the first child of .wrapper: SlideOut pins itself with `position: sticky; top: 0`,
-      which needs a static position at or above the top of the scrolled content to be visible
-      from the start.
-    -->
-    <SlideOut
-      title="Slideout Title"
-      :visible="isSlideoutOpen"
-      @close="isSlideoutOpen = false"
-    >
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lacus viverra vitae congue eu consequat ac felis. Netus et malesuada fames ac turpis. Donec massa sapien faucibus et molestie ac feugiat. Cursus turpis massa tincidunt dui. Eget nullam non nisi est sit amet facilisis magna. Porttitor eget dolor morbi non arcu risus quis. Tempus urna et pharetra pharetra massa massa ultricies mi. Facilisi morbi tempus iaculis urna id volutpat lacus laoreet non. Elit eget gravida cum sociis natoque penatibus et. Lobortis mattis aliquam faucibus purus in massa tempor nec. Aliquet eget sit amet tellus cras adipiscing enim eu. Diam vulputate ut pharetra sit amet aliquam. Ultricies mi quis hendrerit dolor magna eget est lorem. Diam sollicitudin tempor id eu nisl nunc mi ipsum. Pellentesque habitant morbi tristique senectus et netus et. Aliquam ultrices sagittis orci a scelerisque purus.</p>
-      <p>Tincidunt dui ut ornare lectus sit amet. Viverra suspendisse potenti nullam ac tortor vitae purus faucibus ornare. Egestas erat imperdiet sed euismod nisi porta lorem. Potenti nullam ac tortor vitae purus faucibus ornare suspendisse sed. Sit amet cursus sit amet dictum sit amet justo donec. Augue mauris augue neque gravida in fermentum. Tristique risus nec feugiat in. Purus viverra accumsan in nisl. Massa sapien faucibus et molestie ac feugiat. Pharetra magna ac placerat vestibulum. Consequat mauris nunc congue nisi vitae.</p>
-      <p>Turpis tincidunt id aliquet risus feugiat in ante. Congue nisi vitae suscipit tellus. Tincidunt id aliquet risus feugiat in ante. Tincidunt ornare massa eget egestas purus. Velit dignissim sodales ut eu sem. Suspendisse sed nisi lacus sed. At lectus urna duis convallis convallis tellus id interdum velit. Dignissim diam quis enim lobortis. Ullamcorper sit amet risus nullam eget. Id volutpat lacus laoreet non curabitur gravida arcu ac tortor.</p>
-      <p>Vestibulum morbi blandit cursus risus at ultrices mi tempus imperdiet. Dui vivamus arcu felis bibendum ut. Enim neque volutpat ac tincidunt vitae semper. Sed vulputate mi sit amet mauris commodo quis imperdiet massa. Maecenas volutpat blandit aliquam etiam erat velit scelerisque. Non diam phasellus vestibulum lorem sed risus ultricies tristique. Nulla aliquet enim tortor at auctor urna nunc id. Faucibus in ornare quam viverra orci sagittis eu volutpat. Viverra adipiscing at in tellus integer feugiat scelerisque varius morbi. Amet tellus cras adipiscing enim eu turpis. Aliquet risus feugiat in ante. Cursus in hac habitasse platea dictumst. Fringilla ut morbi tincidunt augue interdum. Elementum curabitur vitae nunc sed. Egestas dui id ornare arcu odio ut sem nulla. Nisi vitae suscipit tellus mauris a. Vel fringilla est ullamcorper eget nulla facilisi etiam dignissim diam. Tortor at risus viverra adipiscing at in tellus integer.</p>
-      <p>Porta lorem mollis aliquam ut porttitor leo a. Egestas diam in arcu cursus euismod quis viverra. Egestas erat imperdiet sed euismod nisi porta lorem mollis aliquam. Sociis natoque penatibus et magnis dis parturient montes nascetur. Malesuada nunc vel risus commodo viverra maecenas. Viverra nam libero justo laoreet sit amet. Eu augue ut lectus arcu. Sagittis eu volutpat odio facilisis mauris. Etiam non quam lacus suspendisse faucibus interdum posuere. Mi quis hendrerit dolor magna eget est lorem ipsum dolor. Maecenas ultricies mi eget mauris pharetra et ultrices neque ornare. Nulla porttitor massa id neque aliquam vestibulum morbi blandit. Ut enim blandit volutpat maecenas.</p>
-      <p>Gravida quis blandit turpis cursus in hac habitasse platea. Ornare quam viverra orci sagittis eu volutpat odio. Habitant morbi tristique senectus et netus. Cursus metus aliquam eleifend mi in nulla posuere sollicitudin. Nec dui nunc mattis enim ut tellus. Nunc eget lorem dolor sed viverra ipsum nunc. Commodo sed egestas egestas fringilla phasellus faucibus scelerisque. Varius vel pharetra vel turpis nunc eget lorem dolor. Cursus risus at ultrices mi tempus. Velit scelerisque in dictum non. Aliquet bibendum enim facilisis gravida neque convallis a.</p>
-      <p>Enim ut tellus elementum sagittis vitae et leo duis. Luctus venenatis lectus magna fringilla. Lectus vestibulum mattis ullamcorper velit sed ullamcorper morbi tincidunt. Vitae congue eu consequat ac felis donec et odio pellentesque. Purus viverra accumsan in nisl nisi. Curabitur gravida arcu ac tortor dignissim convallis aenean et tortor. Vestibulum lectus mauris ultrices eros in cursus. Ipsum suspendisse ultrices gravida dictum fusce ut. Et netus et malesuada fames ac turpis egestas integer eget. Sed lectus vestibulum mattis ullamcorper.</p>
-    </SlideOut>
-
     <h1>Spec Renderer Reusable Components Playground</h1>
     <div class="component-container">
       <h2>Tooltip</h2>
@@ -86,6 +67,20 @@
       <button @click="isSlideoutOpen = true">
         Open
       </button>
+
+      <SlideOut
+        title="Slideout Title"
+        :visible="isSlideoutOpen"
+        @close="isSlideoutOpen = false"
+      >
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lacus viverra vitae congue eu consequat ac felis. Netus et malesuada fames ac turpis. Donec massa sapien faucibus et molestie ac feugiat. Cursus turpis massa tincidunt dui. Eget nullam non nisi est sit amet facilisis magna. Porttitor eget dolor morbi non arcu risus quis. Tempus urna et pharetra pharetra massa massa ultricies mi. Facilisi morbi tempus iaculis urna id volutpat lacus laoreet non. Elit eget gravida cum sociis natoque penatibus et. Lobortis mattis aliquam faucibus purus in massa tempor nec. Aliquet eget sit amet tellus cras adipiscing enim eu. Diam vulputate ut pharetra sit amet aliquam. Ultricies mi quis hendrerit dolor magna eget est lorem. Diam sollicitudin tempor id eu nisl nunc mi ipsum. Pellentesque habitant morbi tristique senectus et netus et. Aliquam ultrices sagittis orci a scelerisque purus.</p>
+        <p>Tincidunt dui ut ornare lectus sit amet. Viverra suspendisse potenti nullam ac tortor vitae purus faucibus ornare. Egestas erat imperdiet sed euismod nisi porta lorem. Potenti nullam ac tortor vitae purus faucibus ornare suspendisse sed. Sit amet cursus sit amet dictum sit amet justo donec. Augue mauris augue neque gravida in fermentum. Tristique risus nec feugiat in. Purus viverra accumsan in nisl. Massa sapien faucibus et molestie ac feugiat. Pharetra magna ac placerat vestibulum. Consequat mauris nunc congue nisi vitae.</p>
+        <p>Turpis tincidunt id aliquet risus feugiat in ante. Congue nisi vitae suscipit tellus. Tincidunt id aliquet risus feugiat in ante. Tincidunt ornare massa eget egestas purus. Velit dignissim sodales ut eu sem. Suspendisse sed nisi lacus sed. At lectus urna duis convallis convallis tellus id interdum velit. Dignissim diam quis enim lobortis. Ullamcorper sit amet risus nullam eget. Id volutpat lacus laoreet non curabitur gravida arcu ac tortor.</p>
+        <p>Vestibulum morbi blandit cursus risus at ultrices mi tempus imperdiet. Dui vivamus arcu felis bibendum ut. Enim neque volutpat ac tincidunt vitae semper. Sed vulputate mi sit amet mauris commodo quis imperdiet massa. Maecenas volutpat blandit aliquam etiam erat velit scelerisque. Non diam phasellus vestibulum lorem sed risus ultricies tristique. Nulla aliquet enim tortor at auctor urna nunc id. Faucibus in ornare quam viverra orci sagittis eu volutpat. Viverra adipiscing at in tellus integer feugiat scelerisque varius morbi. Amet tellus cras adipiscing enim eu turpis. Aliquet risus feugiat in ante. Cursus in hac habitasse platea dictumst. Fringilla ut morbi tincidunt augue interdum. Elementum curabitur vitae nunc sed. Egestas dui id ornare arcu odio ut sem nulla. Nisi vitae suscipit tellus mauris a. Vel fringilla est ullamcorper eget nulla facilisi etiam dignissim diam. Tortor at risus viverra adipiscing at in tellus integer.</p>
+        <p>Porta lorem mollis aliquam ut porttitor leo a. Egestas diam in arcu cursus euismod quis viverra. Egestas erat imperdiet sed euismod nisi porta lorem mollis aliquam. Sociis natoque penatibus et magnis dis parturient montes nascetur. Malesuada nunc vel risus commodo viverra maecenas. Viverra nam libero justo laoreet sit amet. Eu augue ut lectus arcu. Sagittis eu volutpat odio facilisis mauris. Etiam non quam lacus suspendisse faucibus interdum posuere. Mi quis hendrerit dolor magna eget est lorem ipsum dolor. Maecenas ultricies mi eget mauris pharetra et ultrices neque ornare. Nulla porttitor massa id neque aliquam vestibulum morbi blandit. Ut enim blandit volutpat maecenas.</p>
+        <p>Gravida quis blandit turpis cursus in hac habitasse platea. Ornare quam viverra orci sagittis eu volutpat odio. Habitant morbi tristique senectus et netus. Cursus metus aliquam eleifend mi in nulla posuere sollicitudin. Nec dui nunc mattis enim ut tellus. Nunc eget lorem dolor sed viverra ipsum nunc. Commodo sed egestas egestas fringilla phasellus faucibus scelerisque. Varius vel pharetra vel turpis nunc eget lorem dolor. Cursus risus at ultrices mi tempus. Velit scelerisque in dictum non. Aliquet bibendum enim facilisis gravida neque convallis a.</p>
+        <p>Enim ut tellus elementum sagittis vitae et leo duis. Luctus venenatis lectus magna fringilla. Lectus vestibulum mattis ullamcorper velit sed ullamcorper morbi tincidunt. Vitae congue eu consequat ac felis donec et odio pellentesque. Purus viverra accumsan in nisl nisi. Curabitur gravida arcu ac tortor dignissim convallis aenean et tortor. Vestibulum lectus mauris ultrices eros in cursus. Ipsum suspendisse ultrices gravida dictum fusce ut. Et netus et malesuada fames ac turpis egestas integer eget. Sed lectus vestibulum mattis ullamcorper.</p>
+      </SlideOut>
     </div>
 
     <div class="component-container">
@@ -131,7 +126,6 @@ const isSlideoutOpen = ref<boolean>(false)
 <style lang="scss" scoped>
 .wrapper {
   gap: 12px;
-  min-height: 100vh;
   padding: 0 6px;
 
   .component-container {

--- a/sandbox/pages/ComponentsPlayground.vue
+++ b/sandbox/pages/ComponentsPlayground.vue
@@ -1,5 +1,24 @@
 <template>
   <div class="wrapper">
+    <!--
+      Must stay the first child of .wrapper: SlideOut pins itself with `position: sticky; top: 0`,
+      which needs a static position at or above the top of the scrolled content to be visible
+      from the start.
+    -->
+    <SlideOut
+      title="Slideout Title"
+      :visible="isSlideoutOpen"
+      @close="isSlideoutOpen = false"
+    >
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lacus viverra vitae congue eu consequat ac felis. Netus et malesuada fames ac turpis. Donec massa sapien faucibus et molestie ac feugiat. Cursus turpis massa tincidunt dui. Eget nullam non nisi est sit amet facilisis magna. Porttitor eget dolor morbi non arcu risus quis. Tempus urna et pharetra pharetra massa massa ultricies mi. Facilisi morbi tempus iaculis urna id volutpat lacus laoreet non. Elit eget gravida cum sociis natoque penatibus et. Lobortis mattis aliquam faucibus purus in massa tempor nec. Aliquet eget sit amet tellus cras adipiscing enim eu. Diam vulputate ut pharetra sit amet aliquam. Ultricies mi quis hendrerit dolor magna eget est lorem. Diam sollicitudin tempor id eu nisl nunc mi ipsum. Pellentesque habitant morbi tristique senectus et netus et. Aliquam ultrices sagittis orci a scelerisque purus.</p>
+      <p>Tincidunt dui ut ornare lectus sit amet. Viverra suspendisse potenti nullam ac tortor vitae purus faucibus ornare. Egestas erat imperdiet sed euismod nisi porta lorem. Potenti nullam ac tortor vitae purus faucibus ornare suspendisse sed. Sit amet cursus sit amet dictum sit amet justo donec. Augue mauris augue neque gravida in fermentum. Tristique risus nec feugiat in. Purus viverra accumsan in nisl. Massa sapien faucibus et molestie ac feugiat. Pharetra magna ac placerat vestibulum. Consequat mauris nunc congue nisi vitae.</p>
+      <p>Turpis tincidunt id aliquet risus feugiat in ante. Congue nisi vitae suscipit tellus. Tincidunt id aliquet risus feugiat in ante. Tincidunt ornare massa eget egestas purus. Velit dignissim sodales ut eu sem. Suspendisse sed nisi lacus sed. At lectus urna duis convallis convallis tellus id interdum velit. Dignissim diam quis enim lobortis. Ullamcorper sit amet risus nullam eget. Id volutpat lacus laoreet non curabitur gravida arcu ac tortor.</p>
+      <p>Vestibulum morbi blandit cursus risus at ultrices mi tempus imperdiet. Dui vivamus arcu felis bibendum ut. Enim neque volutpat ac tincidunt vitae semper. Sed vulputate mi sit amet mauris commodo quis imperdiet massa. Maecenas volutpat blandit aliquam etiam erat velit scelerisque. Non diam phasellus vestibulum lorem sed risus ultricies tristique. Nulla aliquet enim tortor at auctor urna nunc id. Faucibus in ornare quam viverra orci sagittis eu volutpat. Viverra adipiscing at in tellus integer feugiat scelerisque varius morbi. Amet tellus cras adipiscing enim eu turpis. Aliquet risus feugiat in ante. Cursus in hac habitasse platea dictumst. Fringilla ut morbi tincidunt augue interdum. Elementum curabitur vitae nunc sed. Egestas dui id ornare arcu odio ut sem nulla. Nisi vitae suscipit tellus mauris a. Vel fringilla est ullamcorper eget nulla facilisi etiam dignissim diam. Tortor at risus viverra adipiscing at in tellus integer.</p>
+      <p>Porta lorem mollis aliquam ut porttitor leo a. Egestas diam in arcu cursus euismod quis viverra. Egestas erat imperdiet sed euismod nisi porta lorem mollis aliquam. Sociis natoque penatibus et magnis dis parturient montes nascetur. Malesuada nunc vel risus commodo viverra maecenas. Viverra nam libero justo laoreet sit amet. Eu augue ut lectus arcu. Sagittis eu volutpat odio facilisis mauris. Etiam non quam lacus suspendisse faucibus interdum posuere. Mi quis hendrerit dolor magna eget est lorem ipsum dolor. Maecenas ultricies mi eget mauris pharetra et ultrices neque ornare. Nulla porttitor massa id neque aliquam vestibulum morbi blandit. Ut enim blandit volutpat maecenas.</p>
+      <p>Gravida quis blandit turpis cursus in hac habitasse platea. Ornare quam viverra orci sagittis eu volutpat odio. Habitant morbi tristique senectus et netus. Cursus metus aliquam eleifend mi in nulla posuere sollicitudin. Nec dui nunc mattis enim ut tellus. Nunc eget lorem dolor sed viverra ipsum nunc. Commodo sed egestas egestas fringilla phasellus faucibus scelerisque. Varius vel pharetra vel turpis nunc eget lorem dolor. Cursus risus at ultrices mi tempus. Velit scelerisque in dictum non. Aliquet bibendum enim facilisis gravida neque convallis a.</p>
+      <p>Enim ut tellus elementum sagittis vitae et leo duis. Luctus venenatis lectus magna fringilla. Lectus vestibulum mattis ullamcorper velit sed ullamcorper morbi tincidunt. Vitae congue eu consequat ac felis donec et odio pellentesque. Purus viverra accumsan in nisl nisi. Curabitur gravida arcu ac tortor dignissim convallis aenean et tortor. Vestibulum lectus mauris ultrices eros in cursus. Ipsum suspendisse ultrices gravida dictum fusce ut. Et netus et malesuada fames ac turpis egestas integer eget. Sed lectus vestibulum mattis ullamcorper.</p>
+    </SlideOut>
+
     <h1>Spec Renderer Reusable Components Playground</h1>
     <div class="component-container">
       <h2>Tooltip</h2>
@@ -67,20 +86,6 @@
       <button @click="isSlideoutOpen = true">
         Open
       </button>
-
-      <SlideOut
-        title="Slideout Title"
-        :visible="isSlideoutOpen"
-        @close="isSlideoutOpen = false"
-      >
-        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lacus viverra vitae congue eu consequat ac felis. Netus et malesuada fames ac turpis. Donec massa sapien faucibus et molestie ac feugiat. Cursus turpis massa tincidunt dui. Eget nullam non nisi est sit amet facilisis magna. Porttitor eget dolor morbi non arcu risus quis. Tempus urna et pharetra pharetra massa massa ultricies mi. Facilisi morbi tempus iaculis urna id volutpat lacus laoreet non. Elit eget gravida cum sociis natoque penatibus et. Lobortis mattis aliquam faucibus purus in massa tempor nec. Aliquet eget sit amet tellus cras adipiscing enim eu. Diam vulputate ut pharetra sit amet aliquam. Ultricies mi quis hendrerit dolor magna eget est lorem. Diam sollicitudin tempor id eu nisl nunc mi ipsum. Pellentesque habitant morbi tristique senectus et netus et. Aliquam ultrices sagittis orci a scelerisque purus.</p>
-        <p>Tincidunt dui ut ornare lectus sit amet. Viverra suspendisse potenti nullam ac tortor vitae purus faucibus ornare. Egestas erat imperdiet sed euismod nisi porta lorem. Potenti nullam ac tortor vitae purus faucibus ornare suspendisse sed. Sit amet cursus sit amet dictum sit amet justo donec. Augue mauris augue neque gravida in fermentum. Tristique risus nec feugiat in. Purus viverra accumsan in nisl. Massa sapien faucibus et molestie ac feugiat. Pharetra magna ac placerat vestibulum. Consequat mauris nunc congue nisi vitae.</p>
-        <p>Turpis tincidunt id aliquet risus feugiat in ante. Congue nisi vitae suscipit tellus. Tincidunt id aliquet risus feugiat in ante. Tincidunt ornare massa eget egestas purus. Velit dignissim sodales ut eu sem. Suspendisse sed nisi lacus sed. At lectus urna duis convallis convallis tellus id interdum velit. Dignissim diam quis enim lobortis. Ullamcorper sit amet risus nullam eget. Id volutpat lacus laoreet non curabitur gravida arcu ac tortor.</p>
-        <p>Vestibulum morbi blandit cursus risus at ultrices mi tempus imperdiet. Dui vivamus arcu felis bibendum ut. Enim neque volutpat ac tincidunt vitae semper. Sed vulputate mi sit amet mauris commodo quis imperdiet massa. Maecenas volutpat blandit aliquam etiam erat velit scelerisque. Non diam phasellus vestibulum lorem sed risus ultricies tristique. Nulla aliquet enim tortor at auctor urna nunc id. Faucibus in ornare quam viverra orci sagittis eu volutpat. Viverra adipiscing at in tellus integer feugiat scelerisque varius morbi. Amet tellus cras adipiscing enim eu turpis. Aliquet risus feugiat in ante. Cursus in hac habitasse platea dictumst. Fringilla ut morbi tincidunt augue interdum. Elementum curabitur vitae nunc sed. Egestas dui id ornare arcu odio ut sem nulla. Nisi vitae suscipit tellus mauris a. Vel fringilla est ullamcorper eget nulla facilisi etiam dignissim diam. Tortor at risus viverra adipiscing at in tellus integer.</p>
-        <p>Porta lorem mollis aliquam ut porttitor leo a. Egestas diam in arcu cursus euismod quis viverra. Egestas erat imperdiet sed euismod nisi porta lorem mollis aliquam. Sociis natoque penatibus et magnis dis parturient montes nascetur. Malesuada nunc vel risus commodo viverra maecenas. Viverra nam libero justo laoreet sit amet. Eu augue ut lectus arcu. Sagittis eu volutpat odio facilisis mauris. Etiam non quam lacus suspendisse faucibus interdum posuere. Mi quis hendrerit dolor magna eget est lorem ipsum dolor. Maecenas ultricies mi eget mauris pharetra et ultrices neque ornare. Nulla porttitor massa id neque aliquam vestibulum morbi blandit. Ut enim blandit volutpat maecenas.</p>
-        <p>Gravida quis blandit turpis cursus in hac habitasse platea. Ornare quam viverra orci sagittis eu volutpat odio. Habitant morbi tristique senectus et netus. Cursus metus aliquam eleifend mi in nulla posuere sollicitudin. Nec dui nunc mattis enim ut tellus. Nunc eget lorem dolor sed viverra ipsum nunc. Commodo sed egestas egestas fringilla phasellus faucibus scelerisque. Varius vel pharetra vel turpis nunc eget lorem dolor. Cursus risus at ultrices mi tempus. Velit scelerisque in dictum non. Aliquet bibendum enim facilisis gravida neque convallis a.</p>
-        <p>Enim ut tellus elementum sagittis vitae et leo duis. Luctus venenatis lectus magna fringilla. Lectus vestibulum mattis ullamcorper velit sed ullamcorper morbi tincidunt. Vitae congue eu consequat ac felis donec et odio pellentesque. Purus viverra accumsan in nisl nisi. Curabitur gravida arcu ac tortor dignissim convallis aenean et tortor. Vestibulum lectus mauris ultrices eros in cursus. Ipsum suspendisse ultrices gravida dictum fusce ut. Et netus et malesuada fames ac turpis egestas integer eget. Sed lectus vestibulum mattis ullamcorper.</p>
-      </SlideOut>
     </div>
 
     <div class="component-container">
@@ -126,6 +131,7 @@ const isSlideoutOpen = ref<boolean>(false)
 <style lang="scss" scoped>
 .wrapper {
   gap: 12px;
+  min-height: 100vh;
   padding: 0 6px;
 
   .component-container {

--- a/src/components/SpecRenderer.spec.ts
+++ b/src/components/SpecRenderer.spec.ts
@@ -35,7 +35,7 @@ describe('<SpecRenderer />', () => {
     expect(wrapper.exists()).toBe(true)
   })
 
-  it('mounts the slideout inside the spec renderer wrapper', async () => {
+  it('opens the slideout toc and renders its content when the trigger button is clicked', async () => {
     const wrapper = mount(SpecRenderer, {
       attachTo: document.body,
       props: {
@@ -51,21 +51,15 @@ describe('<SpecRenderer />', () => {
 
     await flushPromises()
 
-    let slideout = wrapper.element.querySelector('.slideout-toc')
-    expect(slideout).not.toBeNull()
+    const slideoutContainer = wrapper.find('[data-testid="slideout-container"]')
+    expect(slideoutContainer.exists()).toBe(true)
+    expect(slideoutContainer.isVisible()).toBe(false)
 
-    await wrapper.find('.slideout-toc-trigger-button').trigger('click')
+    await wrapper.find('[data-testid="slideout-toc-trigger-button"]').trigger('click')
     await flushPromises()
 
-    const rendererWrapper = wrapper.element
-    const slideoutTarget = rendererWrapper.querySelector('.spec-renderer-slideout-target-inner')
-    slideout = rendererWrapper.querySelector('.slideout-toc')
-
-    expect(slideout).not.toBeNull()
-    expect(slideout?.parentElement).toBe(slideoutTarget)
-    expect(slideoutTarget?.closest('.spec-renderer-wrapper')).toBe(rendererWrapper)
-    expect(document.body.querySelector(':scope > .slideout-toc')).toBeNull()
-    expect(document.body.children[document.body.children.length - 1]).not.toBe(slideout)
+    expect(slideoutContainer.isVisible()).toBe(true)
+    expect(slideoutContainer.findComponent({ name: 'SpecRendererToc' }).exists()).toBe(true)
 
     wrapper.unmount()
   })

--- a/src/components/SpecRenderer.spec.ts
+++ b/src/components/SpecRenderer.spec.ts
@@ -1,21 +1,21 @@
 // Vitest unit test spec file
 
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import SpecRenderer from './SpecRenderer.vue'
 
-vi.mock('../composables', async () => {
-  const { ref } = await import('vue')
-
-  return {
-    default: {
-      useSchemaParser: () => ({
-        parseSpecDocument: vi.fn().mockResolvedValue({ parsedDocument: undefined, tableOfContents: undefined }),
-        parsedDocument: ref({ name: 'Test API' }),
-        tableOfContents: ref([{ id: '/', title: 'Overview' }]),
-      }),
+const minimalOpenApiSpec = JSON.stringify({
+  openapi: '3.0.0',
+  info: { title: 'Test API', version: '1.0.0' },
+  paths: {
+    '/pets': {
+      get: {
+        operationId: 'listPets',
+        summary: 'List pets',
+        responses: { 200: { description: 'ok' } },
+      },
     },
-  }
+  },
 })
 
 describe('<SpecRenderer />', () => {
@@ -39,7 +39,7 @@ describe('<SpecRenderer />', () => {
     const wrapper = mount(SpecRenderer, {
       attachTo: document.body,
       props: {
-        spec: '[]',
+        spec: minimalOpenApiSpec,
       },
       global: {
         stubs: {

--- a/src/components/SpecRenderer.spec.ts
+++ b/src/components/SpecRenderer.spec.ts
@@ -1,8 +1,22 @@
 // Vitest unit test spec file
 
-import { describe, it, expect } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
 import SpecRenderer from './SpecRenderer.vue'
+
+vi.mock('../composables', async () => {
+  const { ref } = await import('vue')
+
+  return {
+    default: {
+      useSchemaParser: () => ({
+        parseSpecDocument: vi.fn().mockResolvedValue({ parsedDocument: undefined, tableOfContents: undefined }),
+        parsedDocument: ref({ name: 'Test API' }),
+        tableOfContents: ref([{ id: '/', title: 'Overview' }]),
+      }),
+    },
+  }
+})
 
 describe('<SpecRenderer />', () => {
   it('renders', () => {
@@ -10,8 +24,49 @@ describe('<SpecRenderer />', () => {
       props: {
         spec: '[]',
       },
+      global: {
+        stubs: {
+          SpecDocument: true,
+          SpecRendererToc: true,
+        },
+      },
     })
 
     expect(wrapper.exists()).toBe(true)
+  })
+
+  it('mounts the slideout inside the spec renderer wrapper', async () => {
+    const wrapper = mount(SpecRenderer, {
+      attachTo: document.body,
+      props: {
+        spec: '[]',
+      },
+      global: {
+        stubs: {
+          SpecDocument: true,
+          SpecRendererToc: true,
+        },
+      },
+    })
+
+    await flushPromises()
+
+    let slideout = wrapper.element.querySelector('.slideout-toc')
+    expect(slideout).not.toBeNull()
+
+    await wrapper.find('.slideout-toc-trigger-button').trigger('click')
+    await flushPromises()
+
+    const rendererWrapper = wrapper.element
+    const slideoutTarget = rendererWrapper.querySelector('.spec-renderer-slideout-target-inner')
+    slideout = rendererWrapper.querySelector('.slideout-toc')
+
+    expect(slideout).not.toBeNull()
+    expect(slideout?.parentElement).toBe(slideoutTarget)
+    expect(slideoutTarget?.closest('.spec-renderer-wrapper')).toBe(rendererWrapper)
+    expect(document.body.querySelector(':scope > .slideout-toc')).toBeNull()
+    expect(document.body.children[document.body.children.length - 1]).not.toBe(slideout)
+
+    wrapper.unmount()
   })
 })

--- a/src/components/SpecRenderer.vue
+++ b/src/components/SpecRenderer.vue
@@ -1,9 +1,16 @@
 <template>
   <div class="spec-renderer-wrapper">
+    <div class="spec-renderer-slideout-target">
+      <div
+        ref="specRendererSlideoutTarget"
+        class="spec-renderer-slideout-target-inner"
+      />
+    </div>
     <div class="spec-renderer-content">
       <SlideOut
-        v-if="tableOfContents"
+        v-if="tableOfContents && specRendererSlideoutTarget"
         class="slideout-toc"
+        :teleport-target="specRendererSlideoutTarget"
         :title="(parsedDocument as ServiceNode)?.name || 'Table of Contents'"
         :visible="slideoutTocVisible"
         @close="slideoutTocVisible = false"
@@ -121,6 +128,7 @@ const { parseSpecDocument, parsedDocument, tableOfContents } = composables.useSc
 
 const currentPathTOC = ref<string>(currentPath)
 const currentPathDOC = ref<string>(currentPath)
+const specRendererSlideoutTarget = ref<HTMLElement | null>(null)
 
 const itemSelected = (id: any) => {
   /*
@@ -210,7 +218,24 @@ watch(() => ({
 .spec-renderer-wrapper {
   box-sizing: border-box;
   container: spec-renderer / inline-size;
+  position: relative;
   width: 100%;
+
+  .spec-renderer-slideout-target {
+    height: 0;
+    left: 0;
+    pointer-events: none;
+    position: sticky;
+    top: 0;
+    width: 100%;
+    z-index: 1000;
+
+    .spec-renderer-slideout-target-inner {
+      height: 100vh;
+      position: relative;
+      width: 100%;
+    }
+  }
 
   .spec-renderer-content {
     display: flex;
@@ -316,7 +341,7 @@ aside {
 
 <style lang="scss">
 /*
-! Needs to be unscoped because .slideout-toc is teleported to the body.
+! Needs to be unscoped because .slideout-toc is teleported by SlideOut.
 Styles for SpecRendererToc that need to live here so that they apply to the TOC when it's rendered in the context of the SpecRenderer.
 Otherwise host app should have control over these styles.
 */

--- a/src/components/SpecRenderer.vue
+++ b/src/components/SpecRenderer.vue
@@ -1,33 +1,26 @@
 <template>
   <div class="spec-renderer-wrapper">
-    <div class="spec-renderer-slideout-target">
-      <div
-        ref="specRendererSlideoutTarget"
-        class="spec-renderer-slideout-target-inner"
+    <SlideOut
+      v-if="tableOfContents"
+      class="slideout-toc"
+      :title="(parsedDocument as ServiceNode)?.name || 'Table of Contents'"
+      :visible="slideoutTocVisible"
+      @close="slideoutTocVisible = false"
+    >
+      <SpecRendererToc
+        v-if="slideoutTocVisible"
+        :base-path="basePath"
+        class="spec-renderer-toc"
+        :control-address-bar="controlAddressBar"
+        :current-path="currentPathTOC"
+        :navigation-type="navigationType"
+        :show-powered-by="showPoweredBy"
+        :table-of-contents="tableOfContents"
+        @item-selected="itemSelected"
       />
-    </div>
-    <div class="spec-renderer-content">
-      <SlideOut
-        v-if="tableOfContents && specRendererSlideoutTarget"
-        class="slideout-toc"
-        :teleport-target="specRendererSlideoutTarget"
-        :title="(parsedDocument as ServiceNode)?.name || 'Table of Contents'"
-        :visible="slideoutTocVisible"
-        @close="slideoutTocVisible = false"
-      >
-        <SpecRendererToc
-          v-if="slideoutTocVisible"
-          :base-path="basePath"
-          class="spec-renderer-toc"
-          :control-address-bar="controlAddressBar"
-          :current-path="currentPathTOC"
-          :navigation-type="navigationType"
-          :show-powered-by="showPoweredBy"
-          :table-of-contents="tableOfContents"
-          @item-selected="itemSelected"
-        />
-      </SlideOut>
+    </SlideOut>
 
+    <div class="spec-renderer-content">
       <aside>
         <SpecRendererToc
           v-if="tableOfContents && !slideoutTocVisible"
@@ -48,6 +41,7 @@
       >
         <button
           class="slideout-toc-trigger-button"
+          data-testid="slideout-toc-trigger-button"
           type="button"
           @click="openSlideoutToc"
         >
@@ -128,7 +122,6 @@ const { parseSpecDocument, parsedDocument, tableOfContents } = composables.useSc
 
 const currentPathTOC = ref<string>(currentPath)
 const currentPathDOC = ref<string>(currentPath)
-const specRendererSlideoutTarget = ref<HTMLElement | null>(null)
 
 const itemSelected = (id: any) => {
   /*
@@ -220,22 +213,6 @@ watch(() => ({
   container: spec-renderer / inline-size;
   position: relative;
   width: 100%;
-
-  .spec-renderer-slideout-target {
-    height: 0;
-    left: 0;
-    pointer-events: none;
-    position: sticky;
-    top: 0;
-    width: 100%;
-    z-index: 1000;
-
-    .spec-renderer-slideout-target-inner {
-      height: 100vh;
-      position: relative;
-      width: 100%;
-    }
-  }
 
   .spec-renderer-content {
     display: flex;
@@ -337,16 +314,15 @@ aside {
     }
   }
 }
-</style>
 
-<style lang="scss">
 /*
-! Needs to be unscoped because .slideout-toc is teleported by SlideOut.
 Styles for SpecRendererToc that need to live here so that they apply to the TOC when it's rendered in the context of the SpecRenderer.
 Otherwise host app should have control over these styles.
+`.spec-renderer-toc` itself carries SpecRenderer's scope attribute (it's passed in as slot content from
+this component's own template), but `:deep()` is needed below for markup that's internal to SlideOut/SpecRendererToc.
 */
 .slideout-toc {
-  .slideout-content {
+  :deep(.slideout-content) {
     flex-grow: 1;
   }
 
@@ -354,7 +330,7 @@ Otherwise host app should have control over these styles.
     height: 100%;
     position: relative; // important, need this for scrolling to selected item
 
-    > {
+    :deep(>) {
       ul > * {
         // overview item
         &:first-child {
@@ -369,7 +345,7 @@ Otherwise host app should have control over these styles.
       }
     }
 
-    .group-item {
+    :deep(.group-item) {
       &.root {
         padding-left: var(--kui-space-40, $kui-space-40);
         padding-right: var(--kui-space-40, $kui-space-40);

--- a/src/components/SpecRenderer.vue
+++ b/src/components/SpecRenderer.vue
@@ -3,6 +3,7 @@
     <SlideOut
       v-if="tableOfContents"
       class="slideout-toc"
+      :document-scrolling-container="documentScrollingContainer"
       :title="(parsedDocument as ServiceNode)?.name || 'Table of Contents'"
       :visible="slideoutTocVisible"
       @close="slideoutTocVisible = false"

--- a/src/components/common/SlideOut.spec.ts
+++ b/src/components/common/SlideOut.spec.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, afterEach, beforeAll } from 'vitest'
+import { mount } from '@vue/test-utils'
+import SlideOut from './SlideOut.vue'
+
+describe('<SlideOut />', () => {
+  beforeAll(() => {
+    // jsdom doesn't implement document.scrollingElement; browsers resolve it to
+    // document.documentElement for standards-mode documents.
+    Object.defineProperty(document, 'scrollingElement', {
+      configurable: true,
+      value: document.documentElement,
+    })
+  })
+
+  afterEach(() => {
+    document.scrollingElement?.classList.remove('spec-renderer-no-scroll')
+    document.querySelectorAll('.spec-renderer-no-scroll').forEach(el => el.classList.remove('spec-renderer-no-scroll'))
+  })
+
+  it('locks the document scrolling element by default when opened, and unlocks on close', async () => {
+    const wrapper = mount(SlideOut, {
+      props: { visible: false },
+    })
+
+    expect(document.scrollingElement?.classList.contains('spec-renderer-no-scroll')).toBe(false)
+
+    await wrapper.setProps({ visible: true })
+    expect(document.scrollingElement?.classList.contains('spec-renderer-no-scroll')).toBe(true)
+
+    await wrapper.setProps({ visible: false })
+    expect(document.scrollingElement?.classList.contains('spec-renderer-no-scroll')).toBe(false)
+  })
+
+  it('locks a host-provided scroll container instead of the document when documentScrollingContainer is set', async () => {
+    const customScrollContainer = document.createElement('div')
+    customScrollContainer.className = 'custom-scroll-container'
+    document.body.appendChild(customScrollContainer)
+
+    const wrapper = mount(SlideOut, {
+      props: {
+        visible: false,
+        documentScrollingContainer: '.custom-scroll-container',
+      },
+    })
+
+    await wrapper.setProps({ visible: true })
+
+    expect(customScrollContainer.classList.contains('spec-renderer-no-scroll')).toBe(true)
+    expect(document.scrollingElement?.classList.contains('spec-renderer-no-scroll')).toBe(false)
+
+    await wrapper.setProps({ visible: false })
+    expect(customScrollContainer.classList.contains('spec-renderer-no-scroll')).toBe(false)
+
+    document.body.removeChild(customScrollContainer)
+  })
+
+  it('falls back to the document scrolling element when documentScrollingContainer matches nothing', async () => {
+    const wrapper = mount(SlideOut, {
+      props: {
+        visible: false,
+        documentScrollingContainer: '.does-not-exist',
+      },
+    })
+
+    await wrapper.setProps({ visible: true })
+
+    expect(document.scrollingElement?.classList.contains('spec-renderer-no-scroll')).toBe(true)
+  })
+})

--- a/src/components/common/SlideOut.vue
+++ b/src/components/common/SlideOut.vue
@@ -71,22 +71,9 @@ const {
 
 const slideoutRef = useTemplateRef('slideout')
 
-// Scroll container to lock and measure against: an explicit selector if given, else the nearest real scrolling ancestor.
-const resolveScrollingContainer = (): Element | null => {
-  if (documentScrollingContainer) {
-    const explicit = document.querySelector(documentScrollingContainer)
-    if (explicit) {
-      return explicit
-    }
-  }
-
-  // walk up to the nearest ancestor that actually scrolls (overflow-y: auto/scroll)
-  let current = slideoutRef.value?.parentElement ?? null
-  while (current && !/auto|scroll/.test(getComputedStyle(current).overflowY)) {
-    current = current.parentElement
-  }
-  return current
-}
+// Scroll container to lock and measure against - same contract as SpecDocument's own documentScrollingContainer handling.
+const resolveScrollingContainer = (): Element | null =>
+  documentScrollingContainer ? document.querySelector(documentScrollingContainer) : null
 
 // Visible height below the sticky root, measured once on open (scroll is locked while open, so it can't change).
 const viewportHeight = ref('100dvh')
@@ -99,12 +86,7 @@ const updateViewportHeight = (): void => {
   }
 
   const scrollParent = resolveScrollingContainer()
-
-  // document.scrollingElement's own box spans all its content, not just the viewport - use window.innerHeight
-  // instead, which also covers the "whole page scrolls" case (no scrolling ancestor found).
-  const visibleBottom = scrollParent && scrollParent !== document.scrollingElement
-    ? scrollParent.getBoundingClientRect().bottom
-    : window.innerHeight
+  const visibleBottom = scrollParent ? scrollParent.getBoundingClientRect().bottom : window.innerHeight
 
   viewportHeight.value = `${visibleBottom - el.getBoundingClientRect().top}px`
 }

--- a/src/components/common/SlideOut.vue
+++ b/src/components/common/SlideOut.vue
@@ -1,9 +1,9 @@
 <template>
-  <Teleport :to="teleportTarget">
-    <div
-      v-bind="attrs"
-      class="slideout"
-    >
+  <div
+    v-bind="attrs"
+    class="slideout"
+  >
+    <div class="slideout-viewport">
       <Transition name="spec-renderer-fade">
         <div
           v-show="visible"
@@ -43,7 +43,7 @@
         </div>
       </Transition>
     </div>
-  </Teleport>
+  </div>
 </template>
 
 <script lang="ts" setup>
@@ -60,7 +60,6 @@ const {
   visible = false,
   title = '',
   maxWidth = '500px',
-  teleportTarget,
 } = defineProps<{
   visible?: boolean
   title?: string
@@ -68,10 +67,6 @@ const {
    * Max width of SlideOut container.
   */
   maxWidth?: string
-  /**
-   * Element SlideOut should mount into.
-   */
-  teleportTarget: string | Element
 }>()
 
 const emit = defineEmits<{
@@ -125,13 +120,21 @@ onUnmounted(() => {
 @use '@/styles/styles' as *;
 
 .slideout {
-  bottom: 0;
+  height: 0;
   left: 0;
   pointer-events: none;
-  position: absolute;
-  right: 0;
+  position: sticky;
   top: 0;
+  width: 100%;
   z-index: 1000;
+
+  // Gives the absolutely positioned backdrop/container below a one-screen-tall
+  // positioning context to fill, since the sticky root above has zero height.
+  .slideout-viewport {
+    height: 100vh;
+    position: relative;
+    width: 100%;
+  }
 
   .slideout-container {
     background-color: var(--kui-color-background, $kui-color-background);

--- a/src/components/common/SlideOut.vue
+++ b/src/components/common/SlideOut.vue
@@ -1,5 +1,5 @@
 <template>
-  <Teleport to="body">
+  <Teleport :to="teleportTarget">
     <div
       v-bind="attrs"
       class="slideout"
@@ -56,24 +56,23 @@ defineOptions({
 
 const attrs = useAttrs()
 
-const props = defineProps({
-  visible: {
-    type: Boolean,
-    default: false,
-  },
-  title: {
-    type: String,
-    default: '',
-  },
+const {
+  visible = false,
+  title = '',
+  maxWidth = '500px',
+  teleportTarget,
+} = defineProps<{
+  visible?: boolean
+  title?: string
   /**
    * Max width of SlideOut container.
+  */
+  maxWidth?: string
+  /**
+   * Element SlideOut should mount into.
    */
-  maxWidth: {
-    type: String,
-    required: false,
-    default: '500px',
-  },
-})
+  teleportTarget: string | Element
+}>()
 
 const emit = defineEmits<{
   (e: 'close'): void
@@ -81,7 +80,7 @@ const emit = defineEmits<{
 
 const handleClose = (e: any): void => {
   // close on escape key
-  if ((props.visible && e.keyCode === 27)) {
+  if ((visible && e.keyCode === 27)) {
     emit('close')
   }
 }
@@ -106,7 +105,7 @@ const toggleBodyScroll = (isActive: boolean): void => {
   }
 }
 
-watch(() => props.visible, async (visible: boolean): Promise<void> => {
+watch(() => visible, async (visible: boolean): Promise<void> => {
   if (visible) {
     toggleEventListeners(true)
     toggleBodyScroll(true)
@@ -126,6 +125,14 @@ onUnmounted(() => {
 @use '@/styles/styles' as *;
 
 .slideout {
+  bottom: 0;
+  left: 0;
+  pointer-events: none;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 1000;
+
   .slideout-container {
     background-color: var(--kui-color-background, $kui-color-background);
     border-left: var(--kui-border-width-10, $kui-border-width-10) solid var(--kui-color-border, $kui-color-border);
@@ -133,15 +140,16 @@ onUnmounted(() => {
     display: flex;
     flex-direction: column;
     flex-grow: 1;
-    height: 100vh;
+    height: 100%;
     inset: 0;
     overflow-y: auto;
-    position: fixed;
+    pointer-events: auto;
+    position: absolute;
     width: 100%;
     z-index: 1000;
 
     @media (min-width: $kui-breakpoint-mobile) {
-      max-width: v-bind('props.maxWidth');
+      max-width: v-bind('maxWidth');
     }
 
     .slideout-header {
@@ -198,8 +206,10 @@ onUnmounted(() => {
 
   .slideout-backdrop {
     background: var(--kui-color-background-overlay, $kui-color-background-overlay);
+    height: 100%;
     inset: 0;
-    position: fixed;
+    pointer-events: auto;
+    position: absolute;
     z-index: 1000;
   }
 }

--- a/src/components/common/SlideOut.vue
+++ b/src/components/common/SlideOut.vue
@@ -230,8 +230,10 @@ onUnmounted(() => {
 </style>
 
 <style lang="scss">
-// must be unscoped since it targets the document's scrolling element or a host-provided scroll container
+// must be unscoped since it targets the document's scrolling element or a host-provided scroll container.
 .spec-renderer-no-scroll {
-  overflow: hidden;
+  // !important is needed because a host-provided scroll container can have its own overflow rules with
+  // higher specificity than this single-class selector (e.g. multiple classes/attribute selectors).
+  overflow: hidden !important;
 }
 </style>

--- a/src/components/common/SlideOut.vue
+++ b/src/components/common/SlideOut.vue
@@ -1,5 +1,6 @@
 <template>
   <div
+    ref="slideout"
     class="slideout"
   >
     <div class="slideout-viewport">
@@ -46,7 +47,7 @@
 </template>
 
 <script lang="ts" setup>
-import { onUnmounted, watch } from 'vue'
+import { onUnmounted, ref, useTemplateRef, watch } from 'vue'
 import { CloseIcon } from '@kong/icons'
 
 const {
@@ -67,6 +68,46 @@ const {
    */
   documentScrollingContainer?: string
 }>()
+
+const slideoutRef = useTemplateRef('slideout')
+
+// Scroll container to lock and measure against: an explicit selector if given, else the nearest real scrolling ancestor.
+const resolveScrollingContainer = (): Element | null => {
+  if (documentScrollingContainer) {
+    const explicit = document.querySelector(documentScrollingContainer)
+    if (explicit) {
+      return explicit
+    }
+  }
+
+  // walk up to the nearest ancestor that actually scrolls (overflow-y: auto/scroll)
+  let current = slideoutRef.value?.parentElement ?? null
+  while (current && !/auto|scroll/.test(getComputedStyle(current).overflowY)) {
+    current = current.parentElement
+  }
+  return current
+}
+
+// Visible height below the sticky root, measured once on open (scroll is locked while open, so it can't change).
+const viewportHeight = ref('100dvh')
+
+const updateViewportHeight = (): void => {
+  const el = slideoutRef.value
+  if (!el) {
+    viewportHeight.value = '100dvh'
+    return
+  }
+
+  const scrollParent = resolveScrollingContainer()
+
+  // document.scrollingElement's own box spans all its content, not just the viewport - use window.innerHeight
+  // instead, which also covers the "whole page scrolls" case (no scrolling ancestor found).
+  const visibleBottom = scrollParent && scrollParent !== document.scrollingElement
+    ? scrollParent.getBoundingClientRect().bottom
+    : window.innerHeight
+
+  viewportHeight.value = `${visibleBottom - el.getBoundingClientRect().top}px`
+}
 
 const emit = defineEmits<{
   (e: 'close'): void
@@ -91,17 +132,8 @@ const toggleEventListeners = (isActive: boolean): void => {
 
 const toggleBodyScroll = (isActive: boolean): void => {
   if (typeof document !== 'undefined') {
-    // by default, use the document's scrolling element to lock scroll.
-    // This is usually the <html> element, but can be overridden by providing a documentScrollingContainer selector prop.
-    let scrollLockElement = document.scrollingElement
-
-    // If a documentScrollingContainer prop is provided, try to find that element and use it instead
-    if (documentScrollingContainer) {
-      const scrollingContainer = document.querySelector(documentScrollingContainer)
-      if (scrollingContainer) {
-        scrollLockElement = scrollingContainer
-      }
-    }
+    // falls back to the document's own scrolling element (usually <html>) if no scrolling ancestor is found
+    const scrollLockElement = resolveScrollingContainer() ?? document.scrollingElement
 
     if (isActive) {
       scrollLockElement?.classList.add('spec-renderer-no-scroll')
@@ -113,6 +145,7 @@ const toggleBodyScroll = (isActive: boolean): void => {
 
 watch(() => visible, async (visible: boolean): Promise<void> => {
   if (visible) {
+    updateViewportHeight() // must run before the scroll lock, which hides the scrolling ancestor's overflow
     toggleEventListeners(true)
     toggleBodyScroll(true)
   } else {
@@ -139,10 +172,9 @@ onUnmounted(() => {
   width: 100%;
   z-index: 1000;
 
-  // Gives the absolutely positioned backdrop/container below a one-screen-tall
-  // positioning context to fill, since the sticky root above has zero height.
+  // gives the absolutely-positioned children a box to fill, since the sticky root above has zero height
   .slideout-viewport {
-    height: 100vh;
+    height: v-bind('viewportHeight');
     position: relative;
     width: 100%;
   }
@@ -230,10 +262,9 @@ onUnmounted(() => {
 </style>
 
 <style lang="scss">
-// must be unscoped since it targets the document's scrolling element or a host-provided scroll container.
+// unscoped: targets an element outside this component (document or host-provided scroll container)
 .spec-renderer-no-scroll {
-  // !important is needed because a host-provided scroll container can have its own overflow rules with
-  // higher specificity than this single-class selector (e.g. multiple classes/attribute selectors).
+  // !important: that element's own overflow rules can outrank this single-class selector
   overflow: hidden !important;
 }
 </style>

--- a/src/components/common/SlideOut.vue
+++ b/src/components/common/SlideOut.vue
@@ -1,6 +1,5 @@
 <template>
   <div
-    v-bind="attrs"
     class="slideout"
   >
     <div class="slideout-viewport">
@@ -47,14 +46,8 @@
 </template>
 
 <script lang="ts" setup>
-import { onUnmounted, watch, useAttrs } from 'vue'
+import { onUnmounted, watch } from 'vue'
 import { CloseIcon } from '@kong/icons'
-
-defineOptions({
-  inheritAttrs: false,
-})
-
-const attrs = useAttrs()
 
 const {
   visible = false,

--- a/src/components/common/SlideOut.vue
+++ b/src/components/common/SlideOut.vue
@@ -53,6 +53,7 @@ const {
   visible = false,
   title = '',
   maxWidth = '500px',
+  documentScrollingContainer = '',
 } = defineProps<{
   visible?: boolean
   title?: string
@@ -60,6 +61,11 @@ const {
    * Max width of SlideOut container.
   */
   maxWidth?: string
+  /**
+   * Selector for the element that scrolls the content behind the SlideOut.
+   * Falls back to the document's own scrolling element when not provided or not found.
+   */
+  documentScrollingContainer?: string
 }>()
 
 const emit = defineEmits<{
@@ -85,10 +91,22 @@ const toggleEventListeners = (isActive: boolean): void => {
 
 const toggleBodyScroll = (isActive: boolean): void => {
   if (typeof document !== 'undefined') {
+    // by default, use the document's scrolling element to lock scroll.
+    // This is usually the <html> element, but can be overridden by providing a documentScrollingContainer selector prop.
+    let scrollLockElement = document.scrollingElement
+
+    // If a documentScrollingContainer prop is provided, try to find that element and use it instead
+    if (documentScrollingContainer) {
+      const scrollingContainer = document.querySelector(documentScrollingContainer)
+      if (scrollingContainer) {
+        scrollLockElement = scrollingContainer
+      }
+    }
+
     if (isActive) {
-      document.scrollingElement?.classList.add('spec-renderer-no-scroll')
+      scrollLockElement?.classList.add('spec-renderer-no-scroll')
     } else {
-      document.scrollingElement?.classList.remove('spec-renderer-no-scroll')
+      scrollLockElement?.classList.remove('spec-renderer-no-scroll')
     }
   }
 }
@@ -212,7 +230,7 @@ onUnmounted(() => {
 </style>
 
 <style lang="scss">
-// must be unscoped since it's targeting the body element
+// must be unscoped since it targets the document's scrolling element or a host-provided scroll container
 .spec-renderer-no-scroll {
   overflow: hidden;
 }


### PR DESCRIPTION
# Summary

Currently the TOC slideout always gets teleported to body, due to which it actually slides out from the entire window's left side even if the spec-renderer was itself rendered inside a container on the page.
What we need is for the slideout to open out from within the container where the spec-renderer itself is rendered/mounted.

The fix is to stop teleporting the TOC slideout to `body` and instead mount it in place inside spec-renderer's own container, so it renders correctly within the container where spec-renderer is itself rendered.

### Changes

- replace `Teleport to="body"` with rendering `SlideOut` in place, within the `SpecRenderer` component
- move the slideout's viewport-pinning trick (zero-height `position: sticky` root + `100vh` inner layer) into `SlideOut` itself, as it's no more teleported
- hoist `<SlideOut>` to be the first child of `.spec-renderer-wrapper` so its sticky root pins correctly from initial render
- remove the `inheritAttrs: false` / `useAttrs()` / `v-bind="attrs"` fallthrough workaround, which was only needed to get attrs through the old Teleport wrapper
- move the `.slideout-toc` styles into `SpecRenderer`'s normal scoped `<style>` block with `:deep()`, instead of a separate unscoped block (we needed it to be a global style earlier because of teleport)

Resolves: https://konghq.atlassian.net/browse/TDX-6413