### PR TITLE
fix: missing auth headers in try_it feature when multiple securitySchemes are defined [TDX-8806]

### DIFF
--- a/src/components/spec-document/try-it/TryItAuth.spec.ts
+++ b/src/components/spec-document/try-it/TryItAuth.spec.ts
@@ -144,6 +144,7 @@ describe('<TryItAuth />', () => {
   })
 
   it('combines headers for schemes in the same security requirement', async () => {
+    vi.useFakeTimers()
     const security = [[
       { id: 'bearer', key: 'BearerAuth', extensions: {}, type: 'http', scheme: 'bearer' },
       { id: 'api-key', key: 'ApiKeyAuth', extensions: {}, type: 'apiKey', in: 'header', name: 'apikey' },
@@ -161,10 +162,7 @@ describe('<TryItAuth />', () => {
     const inputs = wrapper.findAll('input')
     await inputs[0].setValue('jwt-value')
     await inputs[1].setValue('api-key-value')
-    await inputs[0].setValue('jwt-value')
-    await inputs[1].setValue('api-key-value')
     await vi.advanceTimersByTimeAsync(100)
-    await flushPromises()
     await flushPromises()
 
     const { authHeadersMap } = composables.useAuth()

--- a/src/components/spec-document/try-it/TryItAuth.spec.ts
+++ b/src/components/spec-document/try-it/TryItAuth.spec.ts
@@ -161,7 +161,10 @@ describe('<TryItAuth />', () => {
     const inputs = wrapper.findAll('input')
     await inputs[0].setValue('jwt-value')
     await inputs[1].setValue('api-key-value')
-    await new Promise(resolve => setTimeout(resolve, 300))
+    await inputs[0].setValue('jwt-value')
+    await inputs[1].setValue('api-key-value')
+    await vi.advanceTimersByTimeAsync(100)
+    await flushPromises()
     await flushPromises()
 
     const { authHeadersMap } = composables.useAuth()

--- a/src/components/spec-document/try-it/TryItAuth.spec.ts
+++ b/src/components/spec-document/try-it/TryItAuth.spec.ts
@@ -1,10 +1,19 @@
 import { ref } from 'vue'
-import { describe, it, expect } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
 import TryItAuth from './TryItAuth.vue'
+import composables from '@/composables'
 
 
 describe('<TryItAuth />', () => {
+
+  beforeEach(() => {
+    const { activeSecurityScheme, authHeadersMap, authQueryMap, authInputs } = composables.useAuth()
+    activeSecurityScheme.value = ''
+    authHeadersMap.value = {}
+    authQueryMap.value = {}
+    authInputs.value = {}
+  })
 
   it('Should renderer basic auth', async () => {
 
@@ -86,6 +95,34 @@ describe('<TryItAuth />', () => {
       },
     })
     expect(wrapper.html()).toContain('Scopes')
+  })
+
+  it('combines headers for schemes in the same security requirement', async () => {
+    const security = [[
+      { id: 'bearer', key: 'BearerAuth', extensions: {}, type: 'http', scheme: 'bearer' },
+      { id: 'api-key', key: 'ApiKeyAuth', extensions: {}, type: 'apiKey', in: 'header', name: 'apikey' },
+    ]]
+    const group = { title: 'BearerAuth & ApiKeyAuth', key: 'BearerAuth-ApiKeyAuth', schemeList: security[0] }
+    const { activeSecurityScheme } = composables.useAuth()
+    activeSecurityScheme.value = group.key
+    const wrapper = mount(TryItAuth, {
+      props: {
+        data: { id: 'dual-auth', method: 'post', path: '/example', responses: [], servers: [], security },
+      },
+      global: { provide: { 'security-scheme-group-list': ref([group]) } },
+    })
+
+    const inputs = wrapper.findAll('input')
+    await inputs[0].setValue('jwt-value')
+    await inputs[1].setValue('api-key-value')
+    await new Promise(resolve => setTimeout(resolve, 300))
+    await flushPromises()
+
+    const { authHeadersMap } = composables.useAuth()
+    expect(authHeadersMap.value[group.key]).toEqual([
+      { name: 'Authorization', value: 'Bearer jwt-value' },
+      { name: 'apikey', value: 'api-key-value' },
+    ])
   })
 
 })

--- a/src/components/spec-document/try-it/TryItAuth.spec.ts
+++ b/src/components/spec-document/try-it/TryItAuth.spec.ts
@@ -1,9 +1,10 @@
-import { ref } from 'vue'
-import { describe, it, expect, beforeEach } from 'vitest'
-import { mount, flushPromises } from '@vue/test-utils'
+import { ref, nextTick } from 'vue'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mount, flushPromises, enableAutoUnmount } from '@vue/test-utils'
 import TryItAuth from './TryItAuth.vue'
 import composables from '@/composables'
 
+enableAutoUnmount(afterEach)
 
 describe('<TryItAuth />', () => {
 
@@ -13,6 +14,12 @@ describe('<TryItAuth />', () => {
     authHeadersMap.value = {}
     authQueryMap.value = {}
     authInputs.value = {}
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
   })
 
   it('Should renderer basic auth', async () => {
@@ -95,6 +102,45 @@ describe('<TryItAuth />', () => {
       },
     })
     expect(wrapper.html()).toContain('Scopes')
+  })
+
+  it('updates combined headers before OAuth token acquisition returns', async () => {
+    vi.useFakeTimers()
+    const security = [[
+      {
+        id: 'oauth', key: 'OAuth', extensions: {}, type: 'oauth2' as const,
+        flows: { clientCredentials: { tokenUrl: 'https://example.test/token', scopes: {} } },
+      },
+      { id: 'api-key', key: 'ApiKey', extensions: {}, type: 'apiKey' as const, in: 'header' as const, name: 'apikey' },
+    ]]
+    const group = { title: 'OAuth & ApiKey', key: 'OAuth-ApiKey', schemeList: security[0] }
+    const { activeSecurityScheme, authInputs, authHeadersMap } = composables.useAuth()
+    activeSecurityScheme.value = group.key
+    authInputs.value = { 'OAuth-clientId': 'client', 'OAuth-clientSecret': 'secret', 'ApiKey-token': 'key-value' }
+    const tokenResponse = {
+      ok: true,
+      json: async () => ({ access_token: 'new-token', token_type: 'Bearer', expires_in: 60 }),
+    }
+    const fetchMock = vi.fn().mockResolvedValue(tokenResponse)
+    vi.stubGlobal('fetch', fetchMock)
+    const wrapper = mount(TryItAuth, {
+      props: {
+        data: { id: 'oauth-combined', method: 'post', path: '/example', responses: [], servers: [], security },
+      },
+      global: { provide: { 'security-scheme-group-list': ref([group]) } },
+    })
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(await wrapper.vm.auth2ClientCredentialsAuth()).toBe(tokenResponse)
+
+    // The API request uses these headers immediately, before the debounce runs.
+    expect(authHeadersMap.value[group.key]).toEqual([
+      { name: 'Authorization', value: 'Bearer new-token' },
+      { name: 'apikey', value: 'key-value' },
+    ])
+    await wrapper.vm.auth2ClientCredentialsAuth()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
   it('combines headers for schemes in the same security requirement', async () => {

--- a/src/components/spec-document/try-it/TryItAuth.vue
+++ b/src/components/spec-document/try-it/TryItAuth.vue
@@ -229,12 +229,14 @@ const currentSecuritySchemeMap = ref<Record<string, HttpSecurityScheme>>({})
  * Debounced function to update auth headers and queries
  */
 const updateAuthData = useDebounceFn(() => {
+  const headers: Array<Record<string, string>> = []
+  const query: string[] = []
 
-  const append = (key: string, name: string, value: string, schemeIn: string) => {
+  const append = (name: string, value: string, schemeIn: string) => {
     if (schemeIn === 'query') {
-      authQueryMap.value[key] = `${name}=${value}`
+      query.push(`${name}=${value}`)
     } else {
-      authHeadersMap.value[key] = [...[{ name, value }]]
+      headers.push({ name, value })
     }
   }
 
@@ -243,9 +245,11 @@ const updateAuthData = useDebounceFn(() => {
     // @ts-ignore `in` is valid attribute of the schema
     const schemeIn = scheme.in
 
-    // this is handled in TryItAuth2.vue
+    // The token is acquired in TryItAuth2.vue, but it must still be included
+    // when this security requirement contains multiple schemes.
     if (scheme.type === 'oauth2' && scheme.flows.clientCredentials) {
-      return
+      append('Authorization', authInputs.value[`${key}-token`] || 'Bearer', schemeIn)
+      continue
     }
 
     if (scheme.type === 'http' && scheme.scheme === 'basic') {
@@ -253,18 +257,24 @@ const updateAuthData = useDebounceFn(() => {
       const password = authInputs.value[`${key}-password`] || ''
       const basicAuthValue = btoa(`${username}:${password}`)
       // if the scheme is in header, we add it to the headers
-      append(key, 'Authorization', `Basic ${basicAuthValue}`, schemeIn)
+      append('Authorization', `Basic ${basicAuthValue}`, schemeIn)
 
     } else if (scheme.type === 'http' && scheme.scheme === 'bearer') {
       const value = authInputs.value[`${key}-token`] || ''
-      append(key, 'Authorization', `Bearer ${value}`, schemeIn)
+      append('Authorization', `Bearer ${value}`, schemeIn)
 
     } else {
       const value = authInputs.value[`${key}-token`] || ''
       // @ts-ignore `name` is valid attribute of the schema
-      append(key, scheme.name || 'Authorization', value, schemeIn)
+      append(scheme.name || 'Authorization', value, schemeIn)
     }
   }
+
+  // Requests select credentials by security requirement (an AND group), not
+  // by an individual scheme. For a single-scheme requirement the keys match,
+  // which previously hid this bug.
+  authHeadersMap.value[currentSecurityScheme.value] = headers
+  authQueryMap.value[currentSecurityScheme.value] = query.join('&')
 }, 100)
 
 const getSchemeLabel = (scheme: HttpSecurityScheme, defaultName?: string): string => {

--- a/src/components/spec-document/try-it/TryItAuth.vue
+++ b/src/components/spec-document/try-it/TryItAuth.vue
@@ -189,7 +189,10 @@ const auth2ClientCredentialsAuth = async (): Promise<Response | undefined> => {
   if (!auth2ComponentRef.value?.[0]?.auth2ClientCredentialsAuth) {
     return { ok: true } as Response
   }
-  return await auth2ComponentRef.value[0].auth2ClientCredentialsAuth()
+  const response = await auth2ComponentRef.value[0].auth2ClientCredentialsAuth()
+  // The request proceeds immediately after this returns, before the input debounce runs.
+  updateAuthDataImpl()
+  return response
 }
 
 defineExpose({
@@ -226,9 +229,9 @@ const currentSecuritySchemeMap = ref<Record<string, HttpSecurityScheme>>({})
 
 
 /**
- * Debounced function to update auth headers and queries
+ * Update auth headers and queries for the current security requirement.
  */
-const updateAuthData = useDebounceFn(() => {
+const updateAuthDataImpl = () => {
   const headers: Array<Record<string, string>> = []
   const query: string[] = []
 
@@ -275,7 +278,9 @@ const updateAuthData = useDebounceFn(() => {
   // which previously hid this bug.
   authHeadersMap.value[currentSecurityScheme.value] = headers
   authQueryMap.value[currentSecurityScheme.value] = query.join('&')
-}, 100)
+}
+
+const updateAuthData = useDebounceFn(updateAuthDataImpl, 100)
 
 const getSchemeLabel = (scheme: HttpSecurityScheme, defaultName?: string): string => {
   //@ts-ignore `name` is valid property


### PR DESCRIPTION
# Summary

ticket: https://konghq.atlassian.net/browse/TDX-8806

this PR investigates and fix the issue where the 'Try it' feature fails to send authentication headers when an OAS spec defines multiple securitySchemes. While individual schemes (Bearer Auth, APIKey) work correctly, combining them results in headers not being sent in the request or displayed in the shell example, despite being rendered in the UI. This has been verified using reflected responses from HTTPBin.