### PR TITLE
fix(schema-model): preserve descriptions on referenced properties and arrays [TDX-5454]

### DIFF
--- a/src/components/spec-document/SpecDocument.descriptions.spec.ts
+++ b/src/components/spec-document/SpecDocument.descriptions.spec.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import SpecDocument from './SpecDocument.vue'
+import { parseOpenApiSpecDocument } from '@/utils/schema-parser'
+import type { ServiceNode } from '@/types'
+import type { TableOfContentsItem } from '@/stoplight/elements-core'
+
+describe('referenced property descriptions', () => {
+  it.each(['3.0.3', '3.1.0'])('preserves use-site descriptions in OpenAPI %s without changing shared schemas', async (openapi) => {
+    const stopRef = { $ref: '#/components/schemas/Stop' }
+    const spec = {
+      openapi,
+      info: { title: 'Trips', version: '1.0' },
+      paths: {
+        '/trips': {
+          post: {
+            operationId: 'createTrip',
+            requestBody: { content: { 'application/json': { schema: { $ref: '#/components/schemas/Trip' } } } },
+            responses: { 200: { description: 'OK' } },
+          },
+        },
+      },
+      components: { schemas: {
+        Stop: { type: 'object', description: 'A single stop.', properties: { name: { type: 'string' } } },
+        Trip: { type: 'object', properties: {
+          // Prime the dereference cache before references with their own descriptions.
+          defaultStop: stopRef,
+          stops: { type: 'array', description: 'Ordered stops for this trip.', items: stopRef },
+          start: { ...stopRef, description: 'The departure stop.' },
+          end: { ...stopRef, description: 'The arrival stop.' },
+          defaultStops: { type: 'array', items: stopRef },
+          wrappedStop: { description: 'A wrapped stop.', allOf: [stopRef] },
+          emptyStops: { type: 'array', description: '', items: stopRef },
+        } },
+      } },
+    }
+    const { parsedDocument, tableOfContents } = await parseOpenApiSpecDocument(JSON.stringify(spec))
+    const document = parsedDocument as ServiceNode
+    const stop = document.children.find(child => child.uri === '/schemas/Stop')
+    expect(stop?.data.description).toBe('A single stop.')
+
+    const wrapper = mount(SpecDocument, { props: {
+      document,
+      tableOfContents: tableOfContents as TableOfContentsItem[],
+      currentPath: '/operations/createTrip',
+      allowContentScrolling: false,
+    } })
+    const descriptions = {
+      defaultStop: 'A single stop.',
+      stops: 'Ordered stops for this trip.',
+      start: 'The departure stop.',
+      end: 'The arrival stop.',
+      defaultStops: 'A single stop.',
+      wrappedStop: 'A wrapped stop.',
+    }
+    for (const [name, description] of Object.entries(descriptions)) {
+      const row = wrapper.get(`[data-testid="model-property-${name}"]`)
+      expect(row.get('[data-testid="property-field-description"]').text()).toBe(description)
+      expect(row.text()).toContain('Show Child Parameters')
+      await row.get('summary').trigger('click')
+      expect(row.find('[data-testid="model-property-name"]').exists()).toBe(true)
+    }
+    expect(wrapper.get('[data-testid="model-property-emptyStops"]').find('[data-testid="property-field-description"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+})

--- a/src/composables/useSchemaParser.ts
+++ b/src/composables/useSchemaParser.ts
@@ -241,6 +241,8 @@ export default (): {
         continueOnError: true,
         dereference: {
           circular: true,
+          // Preserve use-site descriptions even when the referenced schema is already cached.
+          preservedProperties: ['description'],
         },
         external: false,
         resolve: {

--- a/src/utils/schema-model.ts
+++ b/src/utils/schema-model.ts
@@ -151,13 +151,14 @@ export const resolveSchemaObjectFields = (candidate: unknown): SchemaObject => {
        * - fields listed directly under the model, except items
        * - fields listed under items, so we destructure items
        * - data type as 'array' and format as the array item data type
-       * if a field is present in both items and the model itself, we use the one from items
+       * item fields take precedence, except for the collection's own description
        */
     const candidateWithoutItems = { ...candidate }
     delete candidateWithoutItems.items
     return {
       ...candidateWithoutItems,
       ...resolveAllOf(candidate.items),
+      ...(Object.hasOwn(candidate, 'description') ? { description: candidate.description } : {}),
       type: candidate.type,
       itemType: candidate.items.type,
     }


### PR DESCRIPTION
# Summary

ticket: https://konghq.atlassian.net/browse/TDX-5454

In the spec display when we have a property that is a user defined class or an array of classes, the definition in the main class is not displayed. In the example attached, I want to add more detail to the collection of stops but I can only update the single stop description.

<img width="641" height="96" alt="Screenshot 2026-09-10 at 1 28 26 PM" src="https://github.com/user-attachments/assets/ccca31fd-e876-466b-8922-c750c998279e" />
